### PR TITLE
fix: sort indices after polynomial multiplication

### DIFF
--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -214,7 +214,7 @@ where
             for &j in plong.nonzero.iter() {
                 deg2 = poly_props.semigroup.degrees[j as usize];
                 if deg1 + deg2 > max_deg {
-                    continue;
+                    break;
                 }
                 poly_props
                     .semigroup
@@ -239,6 +239,7 @@ where
             }
         }
         coeff_pool.push(tmp_var);
+        res.nonzero.sort_unstable();
         res
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -46,6 +46,7 @@ fn to_vec(v: DVector<i32>) -> Vec<i32> {
 /// Compute GV or GW invariants
 #[pyfunction]
 #[pyo3(name = "_compute_gvgw")]
+#[pyo3(signature = (generators, grading_vector, q, intnums, find_gv, is_threefold, max_deg=None, min_points=None, nefpart=None, prec=None))]
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn compute_gvgw(
     generators: Vec<Vec<i32>>,


### PR DESCRIPTION
There was a bug where indices were not being sorted after polynomial multiplication. The loop was also set up incorrectly to continue instead of break from the inner loop when the product of monomials exceeded the maximum degree. This fix significantly speeds up multiplication.