### PR TITLE
chore: fixed failing tests due to rug bug

### DIFF
--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -143,7 +143,7 @@ mod tests {
             true_float.assign(&true_rat);
 
             assert_eq!(res_rat, true_rat);
-            assert!((&res_float - &true_float).complete(prec).abs() < 1e-100);
+            assert!((&res_float - &true_float).complete(prec.into()).abs() < 1e-100);
         }
     }
 
@@ -179,7 +179,7 @@ mod tests {
             true_float.assign(&true_rat);
 
             assert_eq!(res_rat, true_rat);
-            assert!((&res_float - &true_float).complete(prec).abs() < 1e-100);
+            assert!((&res_float - &true_float).complete(prec.into()).abs() < 1e-100);
         }
     }
 }

--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -143,7 +143,7 @@ mod tests {
             true_float.assign(&true_rat);
 
             assert_eq!(res_rat, true_rat);
-            assert!((&res_float - &true_float).complete(prec.into()).abs() < 1e-100);
+            assert!((&res_float - &true_float).complete(512).abs() < 1e-100);
         }
     }
 
@@ -179,7 +179,7 @@ mod tests {
             true_float.assign(&true_rat);
 
             assert_eq!(res_rat, true_rat);
-            assert!((&res_float - &true_float).complete(prec.into()).abs() < 1e-100);
+            assert!((&res_float - &true_float).complete(512).abs() < 1e-100);
         }
     }
 }


### PR DESCRIPTION
The tests were failing due to a weird bug in rug where it sometimes expected a `i64` for the precision instead of a `u32`.