### PR TITLE
chore: drop support for python 3.8 and x86 (32-bit)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
             rustup show
           CIBW_TEST_COMMAND: 'pytest -vv {project}'
           CIBW_TEST_REQUIRES: pytest
-          CIBW_SKIP: cp38-macosx_universal2 cp38-macosx_arm64 pp38-* *-musllinux_i686
+          CIBW_SKIP: cp38-* pp38-* *_i686
           CIBW_BUILD_VERBOSITY: 1
       # CIBW has some issues building wheels with MSYS2
       - name: Build wheels (Windows)

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-14]
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.12']
         include:
           - os: windows-latest
             python-version: ""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ crate-type = ["lib", "cdylib"]
 ctrlc = "3.4.4"
 itertools = "0.13.0"
 nalgebra = "0.33.0"
-rug = "1.24.0"
+rug = "1.25.0"
 
 [dependencies.pyo3]
-version = "0.22.0"
-features = ["abi3-py38"]
+version = "0.22.2"
+features = ["abi3-py39"]
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "./docs-header.html" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cygv"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 authors = [
     {name = "Andres Rios Tascon"}
@@ -21,7 +21,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -102,7 +101,7 @@ isort.required-imports = ["from __future__ import annotations"]
 
 [tool.mypy]
 files = "python"
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true


### PR DESCRIPTION
I've had some issues with Python 3.8 in the past, and now I'm having issues with x86 (32-bit), so I decided to drop support for them since no one should be using those anyway.