### PR TITLE
ci: fix a couple of issues with Windows and macOS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
             rustup show
           CIBW_TEST_COMMAND: 'pytest -vv {project}'
           CIBW_TEST_REQUIRES: pytest
-          CIBW_SKIP: cp38-* pp38-* *_i686
+          CIBW_SKIP: cp38-* pp38-* *_i686 pp* cp39-macosx_x86_64 cp310-macosx_x86_64 cp311-macosx_x86_64
           CIBW_BUILD_VERBOSITY: 1
       # CIBW has some issues building wheels with MSYS2
       - name: Build wheels (Windows)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
             mingw-w64-x86_64-python-maturin
             mingw-w64-x86_64-rust
             mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-clang
             mingw-w64-x86_64-cmake
             diffutils
             m4
@@ -72,7 +73,7 @@ jobs:
       - name: Build wheels (Windows)
         if: runner.os == 'Windows'
         run: |
-          python -m build --wheel --no-isolation --outdir wheelhouse
+          CC=clang python -m build --wheel --no-isolation --outdir wheelhouse
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,6 +42,7 @@ jobs:
             mingw-w64-x86_64-python-maturin
             mingw-w64-x86_64-rust
             mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-clang
             mingw-w64-x86_64-cmake
             diffutils
             m4
@@ -56,7 +57,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Pip install the package
-        run: python -m pip install .[tests]
+        run: CC=clang python -m pip install .[tests]
       - name: Run pytest
         run: |
           pytest -vv

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
+          path-type: inherit
           install: >-
             mingw-w64-x86_64-python
             mingw-w64-x86_64-rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,13 +31,13 @@ jobs:
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: UCRT64
+          msystem: MINGW64
           update: true
-          path-type: inherit
           install: >-
-            mingw-w64-ucrt-x86_64-python
-            mingw-w64-ucrt-x86_64-rust
-            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-rust
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-clang
             diffutils
             m4
             make
@@ -46,7 +46,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Build
-        run: cargo build --verbose
+        run: CC=clang cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,13 +31,13 @@ jobs:
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
           path-type: inherit
           install: >-
-            mingw-w64-x86_64-python
-            mingw-w64-x86_64-rust
-            mingw-w64-x86_64-gcc
+            mingw-w64-ucrt-x86_64-python
+            mingw-w64-ucrt-x86_64-rust
+            mingw-w64-ucrt-x86_64-gcc
             diffutils
             m4
             make


### PR DESCRIPTION
The Windows CI started failing while compiling `gpm-mpfr-sys`. I'm fixing it here.