### PR TITLE
chore(bench): add timing and memory benchmarks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,14 @@ cargo test test_threefold             # single test by name
 cargo test --test full_hkty           # single integration test file
 cargo doc --open
 
+# Benchmarks (see the Benchmarks section below)
+cargo bench                           # both targets, quick scenarios only
+cargo bench --bench bench             # wall clock (criterion)
+cargo bench --bench memory            # allocations and peak memory
+cargo bench -- fourfold               # only the scenarios whose id contains "fourfold"
+CYGV_BENCH_HEAVY=1 cargo bench        # add the high-degree scenarios
+CYGV_BENCH_THREADS=1 cargo bench      # pin the worker thread count
+
 # Python (builds the Rust extension via maturin)
 uv sync --extra tests                 # creates .venv and builds the extension
 uv run pytest
@@ -106,6 +114,36 @@ to a temp file and surfaced in the raised `RuntimeError` when the process dies.
 
 Note the transpose convention: the Rust API takes column-major matrices, while the Python API
 takes row-oriented lists (`to_matrix` in `src/python.rs` treats each inner list as a column).
+
+## Benchmarks
+
+Both bench targets are driven by the same scenario list in `benches/common/mod.rs`: a model
+(`threefold`, $h^{1,1} = 2$ hypersurface; `fourfold`, $h^{1,1} = 6$ CICY) crossed with the four
+`Variant`s (GV/GW × rational/float), at a couple of maximum degrees. A scenario id looks like
+`fourfold/deg15/gw-float`, and any argument after `--` that is not a flag filters on it. Adding a
+model or a degree means adding a row to `scenarios()`; nothing else has to change.
+
+- `benches/bench.rs` measures wall clock with criterion. Each scenario carries a `sample_size` and
+  an `expected_secs` (measured on a 6-core machine) that only sizes criterion's measurement window;
+  criterion will suggest raising the target time, which is expected — the window is deliberately
+  set just under one run per sample so slow cases are not sampled twice over.
+- `benches/memory.rs` measures allocations. `cargo bench --bench memory` prints peak live bytes,
+  total bytes allocated, allocation count, peak RSS and wall clock per scenario.
+
+Memory needs care because the bulk of it lives in GMP/MPFR numbers, which C code allocates and
+Rust's global allocator therefore never sees. `benches/memory.rs` installs its own allocation
+functions through `gmp_mpfr_sys::gmp::set_memory_functions` (MPFR routes through the same hooks
+when built against GMP, which is how `gmp-mpfr-sys` builds it) plus a `GlobalAlloc` wrapper, so
+both sides feed the same counters. GMP passes the block size back on free and realloc, so no
+bookkeeping headers are needed. The hooks must be installed before any GMP object exists, which is
+why it happens first thing in `main`. Each scenario then runs in a child process (`--run <id>`,
+spawned by the parent), so peaks do not leak between scenarios and `VmHWM` reflects one scenario
+only. The `gmp-mpfr-sys` dev-dependency must stay compatible with the version `rug` links against.
+
+The high-degree scenarios are gated behind `CYGV_BENCH_HEAVY` because criterion has to run each of
+them ten or more times; the memory target runs everything once, so enabling them there is cheap.
+`CYGV_BENCH_THREADS` pins the worker count (default: one thread per core), which cuts the noise
+when comparing two revisions.
 
 ## Docs
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,16 @@ features = ["abi3-py310"]
 
 [dev-dependencies]
 criterion = { version = "0.8.1", features = ["html_reports"] }
+# Only used by the memory benchmark, to route GMP/MPFR allocations through a
+# counting allocator. Must stay compatible with the version `rug` links against.
+gmp-mpfr-sys = "1.7"
 
 [[bench]]
 name = "bench"
+harness = false
+
+[[bench]]
+name = "memory"
 harness = false
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,12 @@ rug = "1.25.0"
 version = "0.28.2"
 features = ["abi3-py310"]
 
+[dev-dependencies]
+criterion = { version = "0.8.1", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false
+
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "./docs-header.html" ]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,415 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use cygv::hkty::{
+    compute_gv_float_nfold, compute_gv_float_threefold, compute_gv_rat_nfold,
+    compute_gv_rat_threefold, compute_gw_float_nfold, compute_gw_float_threefold,
+    compute_gw_rat_nfold, compute_gw_rat_threefold,
+};
+use nalgebra::{dmatrix, dvector, RowDVector};
+use std::collections::HashMap;
+
+fn benchmark_threefolds(c: &mut Criterion) {
+    let generators = dmatrix![
+         0, 1;
+        -1, 2;
+    ];
+    let grading_vector = RowDVector::from_row_slice(&[3, -1]);
+
+    let q = dmatrix![
+        1,  0;
+        1,  0;
+        1, -1;
+        0,  1;
+        1,  1;
+        2, -1;
+    ];
+    let nefpart = Vec::new();
+
+    let intnums = HashMap::from([
+        ((0, 0, 0), 2),
+        ((0, 0, 1), 1),
+        ((0, 1, 1), -1),
+        ((1, 1, 1), -5),
+    ]);
+
+    let mut low_deg = c.benchmark_group("low degree");
+    low_deg.sample_size(100);
+
+    low_deg.bench_function("threefold GV Rational", |b| {
+        b.iter(|| {
+            compute_gv_rat_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    low_deg.bench_function("threefold GW Rational", |b| {
+        b.iter(|| {
+            compute_gw_rat_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    low_deg.bench_function("threefold GV Float", |b| {
+        b.iter(|| {
+            compute_gv_float_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                200,
+            )
+        })
+    });
+    low_deg.bench_function("threefold GW Float", |b| {
+        b.iter(|| {
+            compute_gw_float_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                200,
+            )
+        })
+    });
+
+    low_deg.finish();
+
+    let mut high_deg = c.benchmark_group("high degree");
+    high_deg.sample_size(10);
+
+    high_deg.bench_function("threefold GV Rational", |b| {
+        b.iter(|| {
+            compute_gv_rat_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(50),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    high_deg.bench_function("threefold GW Rational", |b| {
+        b.iter(|| {
+            compute_gw_rat_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(50),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    high_deg.bench_function("threefold GV Float", |b| {
+        b.iter(|| {
+            compute_gv_float_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(50),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                500,
+            )
+        })
+    });
+    high_deg.bench_function("threefold GW Float", |b| {
+        b.iter(|| {
+            compute_gw_float_threefold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(50),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                500,
+            )
+        })
+    });
+
+    high_deg.finish();
+}
+
+fn benchmark_fourfolds(c: &mut Criterion) {
+    let generators = dmatrix![
+        0,1,0,0,0,0;
+        0,0,0,1,-2,0;
+        0,-4,1,0,0,0;
+        -2,0,1,0,1,0;
+        3,0,0,1,0,-2;
+        0,0,0,-2,2,1;
+    ];
+    let grading_vector = RowDVector::from_row_slice(&[73, -30, 18, -17, -11, -21]);
+
+    let q = dmatrix![
+        1,0,0,0,0,0;
+        1,0,0,0,0,0;
+        1,0,0,0,0,0;
+        1,0,0,0,0,0;
+        0,1,0,0,0,0;
+        0,0,1,0,0,0;
+        8,-4,2,-2,-2,-3;
+        12,-6,3,-3,-2,-4;
+        4,-3,0,-2,-1,-2;
+        0,0,0,1,0,0;
+        0,0,0,0,1,0;
+        0,0,0,0,0,1;
+    ];
+    let nefpart = vec![dvector![0, 1, 2, 3], dvector![4, 5, 6, 7, 8, 9, 10, 11]];
+
+    let intnums = HashMap::from([
+        ((0, 0, 2), 1),
+        ((0, 1, 1), -8),
+        ((0, 1, 3), 4),
+        ((0, 1, 5), 8),
+        ((0, 2, 2), -4),
+        ((0, 3, 3), -8),
+        ((0, 4, 4), -16),
+        ((0, 4, 5), 8),
+        ((0, 5, 5), -16),
+        ((1, 0, 1), -8),
+        ((1, 0, 3), 4),
+        ((1, 0, 5), 8),
+        ((1, 1, 3), 16),
+        ((1, 1, 5), -32),
+        ((1, 3, 3), -16),
+        ((1, 5, 5), 64),
+        ((2, 0, 0), 1),
+        ((2, 0, 2), -4),
+        ((2, 2, 2), 16),
+        ((3, 0, 1), 4),
+        ((3, 0, 3), -8),
+        ((3, 1, 1), 16),
+        ((3, 1, 3), -16),
+        ((4, 0, 4), -16),
+        ((4, 0, 5), 8),
+        ((4, 4, 4), -128),
+        ((4, 4, 5), 32),
+        ((5, 0, 1), 8),
+        ((5, 0, 4), 8),
+        ((5, 0, 5), -16),
+        ((5, 1, 1), -32),
+        ((5, 1, 5), 64),
+        ((5, 4, 4), 32),
+        ((5, 5, 5), -128),
+        ((6, 0, 0), -8),
+        ((6, 0, 3), 16),
+        ((6, 0, 5), -32),
+        ((6, 1, 1), -128),
+        ((6, 1, 3), 64),
+        ((6, 1, 5), 128),
+        ((6, 3, 3), -64),
+        ((6, 5, 5), -256),
+        ((7, 0, 0), 4),
+        ((7, 0, 1), 16),
+        ((7, 0, 3), -16),
+        ((7, 1, 1), 64),
+        ((7, 1, 3), -64),
+        ((7, 3, 3), 64),
+        ((8, 0, 0), 8),
+        ((8, 0, 1), -32),
+        ((8, 0, 5), 64),
+        ((8, 1, 1), 128),
+        ((8, 1, 5), -256),
+        ((8, 5, 5), 512),
+        ((9, 0, 0), -4),
+        ((9, 0, 2), 16),
+        ((9, 2, 2), -64),
+        ((10, 0, 0), -8),
+        ((10, 0, 1), -16),
+        ((10, 1, 1), -64),
+        ((10, 1, 3), 64),
+        ((10, 3, 3), -128),
+        ((11, 0, 0), -16),
+        ((11, 0, 4), -128),
+        ((11, 0, 5), 32),
+        ((11, 4, 4), -768),
+        ((11, 4, 5), 128),
+        ((12, 0, 0), 8),
+        ((12, 0, 4), 32),
+        ((12, 4, 4), 128),
+        ((13, 0, 0), -16),
+        ((13, 0, 1), 64),
+        ((13, 0, 5), -128),
+        ((13, 1, 1), -256),
+        ((13, 1, 5), 512),
+        ((13, 5, 5), -1024),
+    ]);
+
+    let mut low_deg = c.benchmark_group("low degree");
+    low_deg.sample_size(100);
+
+    low_deg.bench_function("fourfold GV Rational", |b| {
+        b.iter(|| {
+            compute_gv_rat_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    low_deg.bench_function("fourfold GW Rational", |b| {
+        b.iter(|| {
+            compute_gw_rat_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    low_deg.bench_function("fourfold GV Float", |b| {
+        b.iter(|| {
+            compute_gv_float_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                200,
+            )
+        })
+    });
+    low_deg.bench_function("fourfold GW Float", |b| {
+        b.iter(|| {
+            compute_gw_float_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(10),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                200,
+            )
+        })
+    });
+
+    low_deg.finish();
+
+    let mut high_deg = c.benchmark_group("high degree");
+    high_deg.sample_size(10);
+
+    high_deg.bench_function("fourfold GV Rational", |b| {
+        b.iter(|| {
+            compute_gv_rat_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(20),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    high_deg.bench_function("fourfold GW Rational", |b| {
+        b.iter(|| {
+            compute_gw_rat_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(20),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+            )
+        })
+    });
+    high_deg.bench_function("fourfold GV Float", |b| {
+        b.iter(|| {
+            compute_gv_float_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(20),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                500,
+            )
+        })
+    });
+    high_deg.bench_function("fourfold GW Float", |b| {
+        b.iter(|| {
+            compute_gw_float_nfold(
+                generators.clone(),
+                grading_vector.clone(),
+                Some(20),
+                None,
+                q.clone(),
+                nefpart.clone(),
+                intnums.clone(),
+                None,
+                1000,
+                500,
+            )
+        })
+    });
+
+    high_deg.finish();
+}
+
+criterion_group!(benches, benchmark_threefolds, benchmark_fourfolds);
+criterion_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -31,10 +31,10 @@ fn benchmark_threefolds(c: &mut Criterion) {
         ((1, 1, 1), -5),
     ]);
 
-    let mut low_deg = c.benchmark_group("low degree");
+    let mut low_deg = c.benchmark_group("Threefold low-degree");
     low_deg.sample_size(100);
 
-    low_deg.bench_function("threefold GV Rational", |b| {
+    low_deg.bench_function("GV Rational", |b| {
         b.iter(|| {
             compute_gv_rat_threefold(
                 generators.clone(),
@@ -49,7 +49,7 @@ fn benchmark_threefolds(c: &mut Criterion) {
             )
         })
     });
-    low_deg.bench_function("threefold GW Rational", |b| {
+    low_deg.bench_function("GW Rational", |b| {
         b.iter(|| {
             compute_gw_rat_threefold(
                 generators.clone(),
@@ -64,7 +64,7 @@ fn benchmark_threefolds(c: &mut Criterion) {
             )
         })
     });
-    low_deg.bench_function("threefold GV Float", |b| {
+    low_deg.bench_function("GV Float", |b| {
         b.iter(|| {
             compute_gv_float_threefold(
                 generators.clone(),
@@ -80,7 +80,7 @@ fn benchmark_threefolds(c: &mut Criterion) {
             )
         })
     });
-    low_deg.bench_function("threefold GW Float", |b| {
+    low_deg.bench_function("GW Float", |b| {
         b.iter(|| {
             compute_gw_float_threefold(
                 generators.clone(),
@@ -99,10 +99,10 @@ fn benchmark_threefolds(c: &mut Criterion) {
 
     low_deg.finish();
 
-    let mut high_deg = c.benchmark_group("high degree");
+    let mut high_deg = c.benchmark_group("Threefold highdegree");
     high_deg.sample_size(10);
 
-    high_deg.bench_function("threefold GV Rational", |b| {
+    high_deg.bench_function("GV Rational", |b| {
         b.iter(|| {
             compute_gv_rat_threefold(
                 generators.clone(),
@@ -117,7 +117,7 @@ fn benchmark_threefolds(c: &mut Criterion) {
             )
         })
     });
-    high_deg.bench_function("threefold GW Rational", |b| {
+    high_deg.bench_function("GW Rational", |b| {
         b.iter(|| {
             compute_gw_rat_threefold(
                 generators.clone(),
@@ -132,7 +132,7 @@ fn benchmark_threefolds(c: &mut Criterion) {
             )
         })
     });
-    high_deg.bench_function("threefold GV Float", |b| {
+    high_deg.bench_function("GV Float", |b| {
         b.iter(|| {
             compute_gv_float_threefold(
                 generators.clone(),
@@ -148,7 +148,7 @@ fn benchmark_threefolds(c: &mut Criterion) {
             )
         })
     });
-    high_deg.bench_function("threefold GW Float", |b| {
+    high_deg.bench_function("GW Float", |b| {
         b.iter(|| {
             compute_gw_float_threefold(
                 generators.clone(),
@@ -274,10 +274,10 @@ fn benchmark_fourfolds(c: &mut Criterion) {
         ((13, 5, 5), -1024),
     ]);
 
-    let mut low_deg = c.benchmark_group("low degree");
+    let mut low_deg = c.benchmark_group("Fourfold low-degree");
     low_deg.sample_size(100);
 
-    low_deg.bench_function("fourfold GV Rational", |b| {
+    low_deg.bench_function("GV Rational", |b| {
         b.iter(|| {
             compute_gv_rat_nfold(
                 generators.clone(),
@@ -292,7 +292,7 @@ fn benchmark_fourfolds(c: &mut Criterion) {
             )
         })
     });
-    low_deg.bench_function("fourfold GW Rational", |b| {
+    low_deg.bench_function("GW Rational", |b| {
         b.iter(|| {
             compute_gw_rat_nfold(
                 generators.clone(),
@@ -307,7 +307,7 @@ fn benchmark_fourfolds(c: &mut Criterion) {
             )
         })
     });
-    low_deg.bench_function("fourfold GV Float", |b| {
+    low_deg.bench_function("GV Float", |b| {
         b.iter(|| {
             compute_gv_float_nfold(
                 generators.clone(),
@@ -323,7 +323,7 @@ fn benchmark_fourfolds(c: &mut Criterion) {
             )
         })
     });
-    low_deg.bench_function("fourfold GW Float", |b| {
+    low_deg.bench_function("GW Float", |b| {
         b.iter(|| {
             compute_gw_float_nfold(
                 generators.clone(),
@@ -342,10 +342,10 @@ fn benchmark_fourfolds(c: &mut Criterion) {
 
     low_deg.finish();
 
-    let mut high_deg = c.benchmark_group("high degree");
+    let mut high_deg = c.benchmark_group("Fourfold high-degree");
     high_deg.sample_size(10);
 
-    high_deg.bench_function("fourfold GV Rational", |b| {
+    high_deg.bench_function("GV Rational", |b| {
         b.iter(|| {
             compute_gv_rat_nfold(
                 generators.clone(),
@@ -360,7 +360,7 @@ fn benchmark_fourfolds(c: &mut Criterion) {
             )
         })
     });
-    high_deg.bench_function("fourfold GW Rational", |b| {
+    high_deg.bench_function("GW Rational", |b| {
         b.iter(|| {
             compute_gw_rat_nfold(
                 generators.clone(),
@@ -375,7 +375,7 @@ fn benchmark_fourfolds(c: &mut Criterion) {
             )
         })
     });
-    high_deg.bench_function("fourfold GV Float", |b| {
+    high_deg.bench_function("GV Float", |b| {
         b.iter(|| {
             compute_gv_float_nfold(
                 generators.clone(),
@@ -391,7 +391,7 @@ fn benchmark_fourfolds(c: &mut Criterion) {
             )
         })
     });
-    high_deg.bench_function("fourfold GW Float", |b| {
+    high_deg.bench_function("GW Float", |b| {
         b.iter(|| {
             compute_gw_float_nfold(
                 generators.clone(),

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,415 +1,51 @@
+//! Wall-clock benchmarks of the full HKTY pipeline.
+//!
+//! Run with `cargo bench --bench bench`. A filter can be passed to run a subset,
+//! e.g. `cargo bench --bench bench -- threefold/deg10`.
+//!
+//! Two environment variables tune what is run:
+//!
+//! - `CYGV_BENCH_HEAVY=1` adds the high-degree cases, which take a few minutes
+//!   each to sample but are the ones dominated by bignum arithmetic.
+//! - `CYGV_BENCH_THREADS=n` pins the number of worker threads, which makes
+//!   results less noisy and comparable across machines.
+
+mod common;
+
+use common::Scenario;
 use criterion::{criterion_group, criterion_main, Criterion};
-use cygv::hkty::{
-    compute_gv_float_nfold, compute_gv_float_threefold, compute_gv_rat_nfold,
-    compute_gv_rat_threefold, compute_gw_float_nfold, compute_gw_float_threefold,
-    compute_gw_rat_nfold, compute_gw_rat_threefold,
-};
-use nalgebra::{dmatrix, dvector, RowDVector};
-use std::collections::HashMap;
+use std::hint::black_box;
+use std::time::Duration;
 
-fn benchmark_threefolds(c: &mut Criterion) {
-    let generators = dmatrix![
-         0, 1;
-        -1, 2;
-    ];
-    let grading_vector = RowDVector::from_row_slice(&[3, -1]);
+fn benchmark_hkty(c: &mut Criterion) {
+    // Scenarios of the same group are emitted contiguously, so a running fold
+    // is enough to collect them.
+    let mut groups: Vec<(String, Vec<Scenario>)> = Vec::new();
+    for scenario in common::scenarios() {
+        match groups.last_mut() {
+            Some((name, cases)) if *name == scenario.group() => cases.push(scenario),
+            _ => groups.push((scenario.group(), vec![scenario])),
+        }
+    }
 
-    let q = dmatrix![
-        1,  0;
-        1,  0;
-        1, -1;
-        0,  1;
-        1,  1;
-        2, -1;
-    ];
-    let nefpart = Vec::new();
+    for (name, cases) in groups {
+        let model = common::model(cases[0].model);
+        let mut group = c.benchmark_group(&name);
+        // A run allocates its own number pools, so there is little state for a
+        // long warm-up to settle; spend the budget on the samples instead.
+        group.warm_up_time(Duration::from_secs(1));
 
-    let intnums = HashMap::from([
-        ((0, 0, 0), 2),
-        ((0, 0, 1), 1),
-        ((0, 1, 1), -1),
-        ((1, 1, 1), -5),
-    ]);
+        for scenario in cases {
+            group.sample_size(scenario.sample_size);
+            group.measurement_time(scenario.measurement_time());
+            group.bench_function(scenario.variant.name(), |b| {
+                b.iter(|| black_box(scenario.run(&model)))
+            });
+        }
 
-    let mut low_deg = c.benchmark_group("Threefold low-degree");
-    low_deg.sample_size(100);
-
-    low_deg.bench_function("GV Rational", |b| {
-        b.iter(|| {
-            compute_gv_rat_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    low_deg.bench_function("GW Rational", |b| {
-        b.iter(|| {
-            compute_gw_rat_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    low_deg.bench_function("GV Float", |b| {
-        b.iter(|| {
-            compute_gv_float_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                200,
-            )
-        })
-    });
-    low_deg.bench_function("GW Float", |b| {
-        b.iter(|| {
-            compute_gw_float_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                200,
-            )
-        })
-    });
-
-    low_deg.finish();
-
-    let mut high_deg = c.benchmark_group("Threefold highdegree");
-    high_deg.sample_size(10);
-
-    high_deg.bench_function("GV Rational", |b| {
-        b.iter(|| {
-            compute_gv_rat_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(50),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    high_deg.bench_function("GW Rational", |b| {
-        b.iter(|| {
-            compute_gw_rat_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(50),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    high_deg.bench_function("GV Float", |b| {
-        b.iter(|| {
-            compute_gv_float_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(50),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                500,
-            )
-        })
-    });
-    high_deg.bench_function("GW Float", |b| {
-        b.iter(|| {
-            compute_gw_float_threefold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(50),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                500,
-            )
-        })
-    });
-
-    high_deg.finish();
+        group.finish();
+    }
 }
 
-fn benchmark_fourfolds(c: &mut Criterion) {
-    let generators = dmatrix![
-        0,1,0,0,0,0;
-        0,0,0,1,-2,0;
-        0,-4,1,0,0,0;
-        -2,0,1,0,1,0;
-        3,0,0,1,0,-2;
-        0,0,0,-2,2,1;
-    ];
-    let grading_vector = RowDVector::from_row_slice(&[73, -30, 18, -17, -11, -21]);
-
-    let q = dmatrix![
-        1,0,0,0,0,0;
-        1,0,0,0,0,0;
-        1,0,0,0,0,0;
-        1,0,0,0,0,0;
-        0,1,0,0,0,0;
-        0,0,1,0,0,0;
-        8,-4,2,-2,-2,-3;
-        12,-6,3,-3,-2,-4;
-        4,-3,0,-2,-1,-2;
-        0,0,0,1,0,0;
-        0,0,0,0,1,0;
-        0,0,0,0,0,1;
-    ];
-    let nefpart = vec![dvector![0, 1, 2, 3], dvector![4, 5, 6, 7, 8, 9, 10, 11]];
-
-    let intnums = HashMap::from([
-        ((0, 0, 2), 1),
-        ((0, 1, 1), -8),
-        ((0, 1, 3), 4),
-        ((0, 1, 5), 8),
-        ((0, 2, 2), -4),
-        ((0, 3, 3), -8),
-        ((0, 4, 4), -16),
-        ((0, 4, 5), 8),
-        ((0, 5, 5), -16),
-        ((1, 0, 1), -8),
-        ((1, 0, 3), 4),
-        ((1, 0, 5), 8),
-        ((1, 1, 3), 16),
-        ((1, 1, 5), -32),
-        ((1, 3, 3), -16),
-        ((1, 5, 5), 64),
-        ((2, 0, 0), 1),
-        ((2, 0, 2), -4),
-        ((2, 2, 2), 16),
-        ((3, 0, 1), 4),
-        ((3, 0, 3), -8),
-        ((3, 1, 1), 16),
-        ((3, 1, 3), -16),
-        ((4, 0, 4), -16),
-        ((4, 0, 5), 8),
-        ((4, 4, 4), -128),
-        ((4, 4, 5), 32),
-        ((5, 0, 1), 8),
-        ((5, 0, 4), 8),
-        ((5, 0, 5), -16),
-        ((5, 1, 1), -32),
-        ((5, 1, 5), 64),
-        ((5, 4, 4), 32),
-        ((5, 5, 5), -128),
-        ((6, 0, 0), -8),
-        ((6, 0, 3), 16),
-        ((6, 0, 5), -32),
-        ((6, 1, 1), -128),
-        ((6, 1, 3), 64),
-        ((6, 1, 5), 128),
-        ((6, 3, 3), -64),
-        ((6, 5, 5), -256),
-        ((7, 0, 0), 4),
-        ((7, 0, 1), 16),
-        ((7, 0, 3), -16),
-        ((7, 1, 1), 64),
-        ((7, 1, 3), -64),
-        ((7, 3, 3), 64),
-        ((8, 0, 0), 8),
-        ((8, 0, 1), -32),
-        ((8, 0, 5), 64),
-        ((8, 1, 1), 128),
-        ((8, 1, 5), -256),
-        ((8, 5, 5), 512),
-        ((9, 0, 0), -4),
-        ((9, 0, 2), 16),
-        ((9, 2, 2), -64),
-        ((10, 0, 0), -8),
-        ((10, 0, 1), -16),
-        ((10, 1, 1), -64),
-        ((10, 1, 3), 64),
-        ((10, 3, 3), -128),
-        ((11, 0, 0), -16),
-        ((11, 0, 4), -128),
-        ((11, 0, 5), 32),
-        ((11, 4, 4), -768),
-        ((11, 4, 5), 128),
-        ((12, 0, 0), 8),
-        ((12, 0, 4), 32),
-        ((12, 4, 4), 128),
-        ((13, 0, 0), -16),
-        ((13, 0, 1), 64),
-        ((13, 0, 5), -128),
-        ((13, 1, 1), -256),
-        ((13, 1, 5), 512),
-        ((13, 5, 5), -1024),
-    ]);
-
-    let mut low_deg = c.benchmark_group("Fourfold low-degree");
-    low_deg.sample_size(100);
-
-    low_deg.bench_function("GV Rational", |b| {
-        b.iter(|| {
-            compute_gv_rat_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    low_deg.bench_function("GW Rational", |b| {
-        b.iter(|| {
-            compute_gw_rat_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    low_deg.bench_function("GV Float", |b| {
-        b.iter(|| {
-            compute_gv_float_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                200,
-            )
-        })
-    });
-    low_deg.bench_function("GW Float", |b| {
-        b.iter(|| {
-            compute_gw_float_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(10),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                200,
-            )
-        })
-    });
-
-    low_deg.finish();
-
-    let mut high_deg = c.benchmark_group("Fourfold high-degree");
-    high_deg.sample_size(10);
-
-    high_deg.bench_function("GV Rational", |b| {
-        b.iter(|| {
-            compute_gv_rat_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(20),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    high_deg.bench_function("GW Rational", |b| {
-        b.iter(|| {
-            compute_gw_rat_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(20),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-            )
-        })
-    });
-    high_deg.bench_function("GV Float", |b| {
-        b.iter(|| {
-            compute_gv_float_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(20),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                500,
-            )
-        })
-    });
-    high_deg.bench_function("GW Float", |b| {
-        b.iter(|| {
-            compute_gw_float_nfold(
-                generators.clone(),
-                grading_vector.clone(),
-                Some(20),
-                None,
-                q.clone(),
-                nefpart.clone(),
-                intnums.clone(),
-                None,
-                1000,
-                500,
-            )
-        })
-    });
-
-    high_deg.finish();
-}
-
-criterion_group!(benches, benchmark_threefolds, benchmark_fourfolds);
+criterion_group!(benches, benchmark_hkty);
 criterion_main!(benches);

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,382 @@
+//! Shared fixtures and scenario definitions for the `cygv` benchmarks.
+//!
+//! This module is compiled into every bench target, and not every target uses
+//! every item, hence the blanket `dead_code` allowance.
+
+#![allow(dead_code)]
+
+use cygv::hkty::{
+    compute_gv_float_nfold, compute_gv_float_threefold, compute_gv_rat_nfold,
+    compute_gv_rat_threefold, compute_gw_float_nfold, compute_gw_float_threefold,
+    compute_gw_rat_nfold, compute_gw_rat_threefold,
+};
+use nalgebra::{dmatrix, dvector, DMatrix, DVector, RowDVector};
+use std::collections::HashMap;
+
+/// Size of the [`cygv::NumberPool`]s used by the benchmarks.
+pub const POOL_SIZE: usize = 1000;
+
+/// Number of threads the benchmarks run with.
+///
+/// Defaults to `None`, i.e. one thread per available core. Set
+/// `CYGV_BENCH_THREADS` to pin it, which makes results less noisy and easier to
+/// compare across machines.
+pub fn n_threads() -> Option<u32> {
+    match std::env::var("CYGV_BENCH_THREADS") {
+        Ok(s) => Some(
+            s.parse()
+                .expect("CYGV_BENCH_THREADS must be a non-negative integer"),
+        ),
+        Err(_) => None,
+    }
+}
+
+/// The input data describing a Calabi-Yau geometry.
+#[derive(Clone)]
+pub struct Model {
+    pub name: &'static str,
+    pub generators: DMatrix<i32>,
+    pub grading_vector: RowDVector<i32>,
+    pub q: DMatrix<i32>,
+    pub nefpart: Vec<DVector<i32>>,
+    pub intnums: HashMap<(usize, usize, usize), i32>,
+    pub is_threefold: bool,
+}
+
+/// Looks up one of the benchmark models by name.
+pub fn model(name: &str) -> Model {
+    match name {
+        "threefold" => threefold(),
+        "fourfold" => fourfold(),
+        _ => panic!("unknown model {name:?}"),
+    }
+}
+
+/// A hypersurface CY threefold with $h^{1,1} = 2$.
+pub fn threefold() -> Model {
+    let generators = dmatrix![
+         0, 1;
+        -1, 2;
+    ];
+    let grading_vector = RowDVector::from_row_slice(&[3, -1]);
+
+    let q = dmatrix![
+        1,  0;
+        1,  0;
+        1, -1;
+        0,  1;
+        1,  1;
+        2, -1;
+    ];
+    let nefpart = Vec::new();
+
+    let intnums = HashMap::from([
+        ((0, 0, 0), 2),
+        ((0, 0, 1), 1),
+        ((0, 1, 1), -1),
+        ((1, 1, 1), -5),
+    ]);
+
+    Model {
+        name: "threefold",
+        generators,
+        grading_vector,
+        q,
+        nefpart,
+        intnums,
+        is_threefold: true,
+    }
+}
+
+/// A complete intersection CY fourfold with $h^{1,1} = 6$.
+pub fn fourfold() -> Model {
+    let generators = dmatrix![
+        0,1,0,0,0,0;
+        0,0,0,1,-2,0;
+        0,-4,1,0,0,0;
+        -2,0,1,0,1,0;
+        3,0,0,1,0,-2;
+        0,0,0,-2,2,1;
+    ];
+    let grading_vector = RowDVector::from_row_slice(&[73, -30, 18, -17, -11, -21]);
+
+    let q = dmatrix![
+        1,0,0,0,0,0;
+        1,0,0,0,0,0;
+        1,0,0,0,0,0;
+        1,0,0,0,0,0;
+        0,1,0,0,0,0;
+        0,0,1,0,0,0;
+        8,-4,2,-2,-2,-3;
+        12,-6,3,-3,-2,-4;
+        4,-3,0,-2,-1,-2;
+        0,0,0,1,0,0;
+        0,0,0,0,1,0;
+        0,0,0,0,0,1;
+    ];
+    let nefpart = vec![dvector![0, 1, 2, 3], dvector![4, 5, 6, 7, 8, 9, 10, 11]];
+
+    let intnums = HashMap::from([
+        ((0, 0, 2), 1),
+        ((0, 1, 1), -8),
+        ((0, 1, 3), 4),
+        ((0, 1, 5), 8),
+        ((0, 2, 2), -4),
+        ((0, 3, 3), -8),
+        ((0, 4, 4), -16),
+        ((0, 4, 5), 8),
+        ((0, 5, 5), -16),
+        ((1, 0, 1), -8),
+        ((1, 0, 3), 4),
+        ((1, 0, 5), 8),
+        ((1, 1, 3), 16),
+        ((1, 1, 5), -32),
+        ((1, 3, 3), -16),
+        ((1, 5, 5), 64),
+        ((2, 0, 0), 1),
+        ((2, 0, 2), -4),
+        ((2, 2, 2), 16),
+        ((3, 0, 1), 4),
+        ((3, 0, 3), -8),
+        ((3, 1, 1), 16),
+        ((3, 1, 3), -16),
+        ((4, 0, 4), -16),
+        ((4, 0, 5), 8),
+        ((4, 4, 4), -128),
+        ((4, 4, 5), 32),
+        ((5, 0, 1), 8),
+        ((5, 0, 4), 8),
+        ((5, 0, 5), -16),
+        ((5, 1, 1), -32),
+        ((5, 1, 5), 64),
+        ((5, 4, 4), 32),
+        ((5, 5, 5), -128),
+        ((6, 0, 0), -8),
+        ((6, 0, 3), 16),
+        ((6, 0, 5), -32),
+        ((6, 1, 1), -128),
+        ((6, 1, 3), 64),
+        ((6, 1, 5), 128),
+        ((6, 3, 3), -64),
+        ((6, 5, 5), -256),
+        ((7, 0, 0), 4),
+        ((7, 0, 1), 16),
+        ((7, 0, 3), -16),
+        ((7, 1, 1), 64),
+        ((7, 1, 3), -64),
+        ((7, 3, 3), 64),
+        ((8, 0, 0), 8),
+        ((8, 0, 1), -32),
+        ((8, 0, 5), 64),
+        ((8, 1, 1), 128),
+        ((8, 1, 5), -256),
+        ((8, 5, 5), 512),
+        ((9, 0, 0), -4),
+        ((9, 0, 2), 16),
+        ((9, 2, 2), -64),
+        ((10, 0, 0), -8),
+        ((10, 0, 1), -16),
+        ((10, 1, 1), -64),
+        ((10, 1, 3), 64),
+        ((10, 3, 3), -128),
+        ((11, 0, 0), -16),
+        ((11, 0, 4), -128),
+        ((11, 0, 5), 32),
+        ((11, 4, 4), -768),
+        ((11, 4, 5), 128),
+        ((12, 0, 0), 8),
+        ((12, 0, 4), 32),
+        ((12, 4, 4), 128),
+        ((13, 0, 0), -16),
+        ((13, 0, 1), 64),
+        ((13, 0, 5), -128),
+        ((13, 1, 1), -256),
+        ((13, 1, 5), 512),
+        ((13, 5, 5), -1024),
+    ]);
+
+    Model {
+        name: "fourfold",
+        generators,
+        grading_vector,
+        q,
+        nefpart,
+        intnums,
+        is_threefold: false,
+    }
+}
+
+/// The invariants to compute and the coefficient type to compute them with.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Variant {
+    GvRat,
+    GwRat,
+    GvFloat,
+    GwFloat,
+}
+
+impl Variant {
+    pub const ALL: [Variant; 4] = [
+        Variant::GvRat,
+        Variant::GwRat,
+        Variant::GvFloat,
+        Variant::GwFloat,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Variant::GvRat => "gv-rational",
+            Variant::GwRat => "gw-rational",
+            Variant::GvFloat => "gv-float",
+            Variant::GwFloat => "gw-float",
+        }
+    }
+}
+
+/// A single benchmark case: one model, up to one degree, with one variant.
+pub struct Scenario {
+    pub model: &'static str,
+    pub max_deg: u32,
+    pub variant: Variant,
+    /// Precision of the floating-point variants, in bits. Ignored by the exact
+    /// ones.
+    pub precision: u32,
+    /// Number of samples criterion should collect for this case.
+    pub sample_size: usize,
+    /// Rough time of a single run, in seconds, measured on a 6-core machine.
+    /// Only used to size criterion's measurement window; being off by a factor
+    /// of a few costs time but does not affect what is reported.
+    pub expected_secs: f64,
+    /// Whether this case is only run when `CYGV_BENCH_HEAVY` is set.
+    pub heavy: bool,
+}
+
+impl Scenario {
+    /// Name of the criterion group this case belongs to.
+    pub fn group(&self) -> String {
+        format!("{}/deg{}", self.model, self.max_deg)
+    }
+
+    /// Fully qualified name, unique across all scenarios.
+    pub fn id(&self) -> String {
+        format!("{}/{}", self.group(), self.variant.name())
+    }
+
+    /// How long criterion should keep sampling this case.
+    ///
+    /// Criterion rounds the number of iterations per sample up, so the window is
+    /// kept just under what one run per sample needs; asking for slightly more
+    /// than that would double the time spent on the case. Criterion therefore
+    /// suggests raising the target time on every slow case, which is expected.
+    pub fn measurement_time(&self) -> std::time::Duration {
+        let secs = 0.9 * self.expected_secs * self.sample_size as f64;
+        std::time::Duration::from_secs_f64(secs.max(1.0))
+    }
+
+    /// Runs the case, returning the number of invariants that were computed.
+    ///
+    /// The model is passed in so that constructing it is not part of what is
+    /// being measured; the entry points consume their arguments, so it still
+    /// has to be cloned on every call.
+    pub fn run(&self, m: &Model) -> usize {
+        let gens = m.generators.clone();
+        let grading = m.grading_vector.clone();
+        let deg = Some(self.max_deg);
+        let q = m.q.clone();
+        let nefpart = m.nefpart.clone();
+        let intnums = m.intnums.clone();
+        let threads = n_threads();
+        let prec = self.precision;
+
+        match (self.variant, m.is_threefold) {
+            (Variant::GvRat, true) => compute_gv_rat_threefold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE,
+            )
+            .len(),
+            (Variant::GwRat, true) => compute_gw_rat_threefold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE,
+            )
+            .len(),
+            (Variant::GvFloat, true) => compute_gv_float_threefold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE, prec,
+            )
+            .len(),
+            (Variant::GwFloat, true) => compute_gw_float_threefold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE, prec,
+            )
+            .len(),
+            (Variant::GvRat, false) => compute_gv_rat_nfold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE,
+            )
+            .len(),
+            (Variant::GwRat, false) => compute_gw_rat_nfold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE,
+            )
+            .len(),
+            (Variant::GvFloat, false) => compute_gv_float_nfold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE, prec,
+            )
+            .len(),
+            (Variant::GwFloat, false) => compute_gw_float_nfold(
+                gens, grading, deg, None, None, q, nefpart, intnums, threads, POOL_SIZE, prec,
+            )
+            .len(),
+        }
+    }
+}
+
+/// All benchmark cases, in the order they should be run.
+///
+/// The low-degree cases run fast enough for criterion to sample them properly.
+/// The heavy ones are where the coefficients grow large enough for the bignum
+/// arithmetic, the number pools and the sliding window of the series inversion
+/// to dominate, which is what most changes to this crate are about; they are
+/// skipped unless `CYGV_BENCH_HEAVY` is set, since sampling them takes minutes.
+pub fn scenarios() -> Vec<Scenario> {
+    // Per-run times are for one variant on a 6-core machine, in the order of
+    // `Variant::ALL`. The `gw-float` n-fold case is the outlier: without an
+    // exact zero to compare against it keeps every near-zero invariant, so it
+    // computes two orders of magnitude more of them than its rational
+    // counterpart.
+    //
+    //  model,       deg, prec, samples, per-run secs,             heavy
+    let cases = [
+        ("threefold", 10, 200, 100, [0.01, 0.01, 0.01, 0.01], false),
+        ("threefold", 30, 500, 10, [0.76, 0.66, 0.75, 0.59], false),
+        ("fourfold", 10, 200, 20, [0.09, 0.11, 0.08, 0.33], false),
+        ("threefold", 50, 500, 10, [9.6, 7.8, 8.1, 6.2], true),
+        ("fourfold", 15, 500, 10, [1.13, 1.50, 1.16, 15.07], true),
+    ];
+
+    let heavy_enabled = std::env::var_os("CYGV_BENCH_HEAVY").is_some();
+
+    cases
+        .into_iter()
+        .filter(|(_, _, _, _, _, heavy)| heavy_enabled || !heavy)
+        .flat_map(
+            |(model, max_deg, precision, sample_size, expected_secs, heavy)| {
+                Variant::ALL
+                    .into_iter()
+                    .zip(expected_secs)
+                    .map(move |(variant, expected_secs)| Scenario {
+                        model,
+                        max_deg,
+                        variant,
+                        precision,
+                        sample_size,
+                        expected_secs,
+                        heavy,
+                    })
+            },
+        )
+        .collect()
+}
+
+/// Returns the scenarios whose id contains one of the given filters. An empty
+/// filter list matches everything.
+pub fn filtered_scenarios(filters: &[String]) -> Vec<Scenario> {
+    scenarios()
+        .into_iter()
+        .filter(|s| filters.is_empty() || filters.iter().any(|f| s.id().contains(f.as_str())))
+        .collect()
+}

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -1,0 +1,329 @@
+//! Memory benchmarks of the full HKTY pipeline.
+//!
+//! Run with `cargo bench --bench memory`. A filter can be passed to run a
+//! subset, e.g. `cargo bench --bench memory -- threefold/deg10`, and the same
+//! `CYGV_BENCH_HEAVY` and `CYGV_BENCH_THREADS` variables as the wall-clock
+//! benchmarks apply. Each scenario is run exactly once, so enabling the heavy
+//! cases here is much cheaper than it is there.
+//!
+//! Almost all of the memory this crate uses is held by GMP/MPFR numbers, which
+//! are allocated by C code and therefore never reach Rust's global allocator.
+//! To account for them, this benchmark installs its own allocation functions
+//! with `mp_set_memory_functions` (MPFR routes its allocations through the same
+//! hooks) alongside a global allocator wrapper, so every allocation on either
+//! side is counted. GMP hands the size back on free and realloc, so the tracking
+//! needs no bookkeeping of its own beyond a few counters.
+//!
+//! Each scenario runs in its own child process. That keeps one scenario's peak
+//! from leaking into the next one, and it lets the child report a peak RSS that
+//! covers everything a counter cannot see (thread stacks, allocator overhead,
+//! fragmentation).
+
+mod common;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::ffi::c_void;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+/// Bytes currently held by live allocations.
+static CURRENT: AtomicUsize = AtomicUsize::new(0);
+/// High-water mark of `CURRENT`.
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+/// Bytes handed out over the whole run, counting only the growth of a realloc.
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
+/// Number of allocation and reallocation calls.
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+fn on_alloc(size: usize) {
+    let current = CURRENT.fetch_add(size, Ordering::Relaxed) + size;
+    PEAK.fetch_max(current, Ordering::Relaxed);
+    TOTAL.fetch_add(size, Ordering::Relaxed);
+    COUNT.fetch_add(1, Ordering::Relaxed);
+}
+
+fn on_free(size: usize) {
+    CURRENT.fetch_sub(size, Ordering::Relaxed);
+}
+
+fn on_realloc(old_size: usize, new_size: usize) {
+    if new_size >= old_size {
+        on_alloc(new_size - old_size);
+    } else {
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        on_free(old_size - new_size);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rust side
+// ---------------------------------------------------------------------------
+
+struct TrackingAllocator;
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            on_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            on_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        on_free(layout.size());
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            on_realloc(layout.size(), new_size);
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+// ---------------------------------------------------------------------------
+// GMP/MPFR side
+// ---------------------------------------------------------------------------
+
+/// Alignment of the blocks handed to GMP. It only requires `mp_limb_t`
+/// alignment, but matching `max_align_t` keeps this safe for the odd struct
+/// MPFR allocates through the same hooks.
+const GMP_ALIGN: usize = 16;
+
+/// GMP never asks for zero bytes, but the layout has to be valid regardless,
+/// and the same adjustment has to be made when the block comes back.
+fn gmp_layout(size: usize) -> Layout {
+    Layout::from_size_align(size.max(1), GMP_ALIGN).expect("invalid GMP allocation size")
+}
+
+// GMP declares its allocation functions as safe `extern "C"` pointers, so these
+// cannot be marked `unsafe` even though they are only ever called by GMP, with
+// the pointers and sizes it got from here.
+extern "C" fn gmp_alloc(size: usize) -> *mut c_void {
+    let ptr = unsafe { System.alloc(gmp_layout(size)) };
+    if ptr.is_null() {
+        std::alloc::handle_alloc_error(gmp_layout(size));
+    }
+    on_alloc(size);
+    ptr.cast()
+}
+
+extern "C" fn gmp_realloc(ptr: *mut c_void, old_size: usize, new_size: usize) -> *mut c_void {
+    let new_ptr = unsafe { System.realloc(ptr.cast(), gmp_layout(old_size), new_size.max(1)) };
+    if new_ptr.is_null() {
+        std::alloc::handle_alloc_error(gmp_layout(new_size));
+    }
+    on_realloc(old_size, new_size);
+    new_ptr.cast()
+}
+
+extern "C" fn gmp_free(ptr: *mut c_void, size: usize) {
+    on_free(size);
+    unsafe { System.dealloc(ptr.cast(), gmp_layout(size)) }
+}
+
+/// Routes GMP and MPFR allocations through the counters.
+///
+/// # Safety
+///
+/// Must be called before any GMP or MPFR object exists, since blocks allocated
+/// by the previous functions would be freed by the new ones.
+unsafe fn install_gmp_hooks() {
+    unsafe {
+        gmp_mpfr_sys::gmp::set_memory_functions(Some(gmp_alloc), Some(gmp_realloc), Some(gmp_free))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+/// Peak resident set size of this process, in bytes, if the platform reports it.
+fn peak_rss() -> Option<usize> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        let line = status.lines().find(|l| l.starts_with("VmHWM:"))?;
+        let kib: usize = line.split_whitespace().nth(1)?.parse().ok()?;
+        Some(kib * 1024)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+fn human_bytes(bytes: usize) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+struct Measurement {
+    peak: usize,
+    total: usize,
+    allocs: usize,
+    rss: Option<usize>,
+    secs: f64,
+    results: usize,
+}
+
+impl Measurement {
+    /// Serialized on a single line so the parent process can read it back.
+    fn encode(&self) -> String {
+        format!(
+            "RESULT peak={} total={} allocs={} rss={} secs={} results={}",
+            self.peak,
+            self.total,
+            self.allocs,
+            self.rss.map_or(-1, |r| r as i64),
+            self.secs,
+            self.results,
+        )
+    }
+
+    fn decode(line: &str) -> Option<Measurement> {
+        let mut fields = std::collections::HashMap::new();
+        for field in line.strip_prefix("RESULT ")?.split_whitespace() {
+            let (key, value) = field.split_once('=')?;
+            fields.insert(key, value);
+        }
+        let get = |key: &str| fields.get(key).copied();
+        let rss = get("rss")?.parse::<i64>().ok()?;
+        Some(Measurement {
+            peak: get("peak")?.parse().ok()?,
+            total: get("total")?.parse().ok()?,
+            allocs: get("allocs")?.parse().ok()?,
+            rss: (rss >= 0).then_some(rss as usize),
+            secs: get("secs")?.parse().ok()?,
+            results: get("results")?.parse().ok()?,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+/// Runs a single scenario and reports what it used.
+fn measure(id: &str) -> Measurement {
+    let scenario = common::scenarios()
+        .into_iter()
+        .find(|s| s.id() == id)
+        .unwrap_or_else(|| panic!("unknown scenario {id:?}"));
+    let model = common::model(scenario.model);
+
+    // Anything allocated before this point (the model, the process itself) is
+    // not part of what is being measured.
+    let baseline = CURRENT.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+    TOTAL.store(0, Ordering::Relaxed);
+    COUNT.store(0, Ordering::Relaxed);
+
+    let start = Instant::now();
+    let results = scenario.run(&model);
+    let secs = start.elapsed().as_secs_f64();
+
+    Measurement {
+        peak: PEAK.load(Ordering::Relaxed).saturating_sub(baseline),
+        total: TOTAL.load(Ordering::Relaxed),
+        allocs: COUNT.load(Ordering::Relaxed),
+        rss: peak_rss(),
+        secs,
+        results,
+    }
+}
+
+fn run_child(id: &str) {
+    println!("{}", measure(id).encode());
+}
+
+fn run_parent(filters: &[String]) {
+    let scenarios = common::filtered_scenarios(filters);
+    if scenarios.is_empty() {
+        eprintln!("no scenarios matched {filters:?}");
+        std::process::exit(1);
+    }
+
+    let exe = std::env::current_exe().expect("cannot locate the benchmark binary");
+
+    println!(
+        "{:<32} {:>12} {:>12} {:>12} {:>12} {:>10} {:>10}",
+        "scenario", "peak alloc", "total alloc", "allocs", "peak RSS", "time (s)", "results"
+    );
+
+    for scenario in scenarios {
+        let id = scenario.id();
+        let output = Command::new(&exe)
+            .arg("--run")
+            .arg(&id)
+            .output()
+            .expect("failed to spawn the benchmark child process");
+
+        if !output.status.success() {
+            eprintln!("{id}: child process failed ({})", output.status);
+            eprint!("{}", String::from_utf8_lossy(&output.stderr));
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let Some(measurement) = stdout.lines().find_map(Measurement::decode) else {
+            eprintln!("{id}: child process produced no measurement");
+            continue;
+        };
+
+        println!(
+            "{:<32} {:>12} {:>12} {:>12} {:>12} {:>10.3} {:>10}",
+            id,
+            human_bytes(measurement.peak),
+            human_bytes(measurement.total),
+            measurement.allocs,
+            measurement.rss.map_or("n/a".to_string(), human_bytes),
+            measurement.secs,
+            measurement.results,
+        );
+    }
+}
+
+fn main() {
+    // Nothing may touch GMP or MPFR before this point.
+    unsafe { install_gmp_hooks() };
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.iter().position(|a| a == "--run") {
+        Some(pos) => {
+            let id = args.get(pos + 1).expect("--run needs a scenario id");
+            run_child(id);
+        }
+        // Cargo passes flags such as `--bench` that do not apply here; anything
+        // else is treated as a filter on the scenario ids.
+        None => {
+            let filters: Vec<String> = args.into_iter().filter(|a| !a.starts_with('-')).collect();
+            run_parent(&filters);
+        }
+    }
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a benchmarking setup so that changes to the pipeline can be checked for
performance regressions, both in time and in memory.

## What is here

- `benches/common/mod.rs` — the fixtures and the scenario list both bench
  targets are driven from. A scenario is a model (`threefold`, an $h^{1,1} = 2$
  hypersurface; `fourfold`, an $h^{1,1} = 6$ CICY) at a maximum degree, crossed
  with the four variants (GV/GW × rational/float), and is named e.g.
  `fourfold/deg15/gw-float`. Adding a model or a degree is one row in
  `scenarios()`.
- `benches/bench.rs` — wall clock, via criterion. Sample counts and measurement
  windows come from measured per-run times, so criterion does exactly one run
  per sample instead of silently sampling the slow cases twice over.
- `benches/memory.rs` — allocations. Reports peak live bytes, total bytes
  allocated, allocation count, peak RSS and wall clock per scenario.

Most of the memory this crate uses is held by GMP/MPFR numbers, which C code
allocates and Rust's global allocator therefore never sees. The memory target
installs its own allocation functions through `mp_set_memory_functions` (MPFR
routes through the same hooks when built against GMP) alongside a `GlobalAlloc`
wrapper, so both sides feed the same counters; GMP passes the block size back on
free and realloc, so no bookkeeping headers are needed. Each scenario then runs
in a child process, so peaks do not leak between scenarios and `VmHWM` reflects
one scenario only.

Along the way this fixes the benchmarks added in the earlier commits, which did
not compile: every call site was missing the `target_points` argument.

## Running them

```bash
cargo bench                           # both targets, quick scenarios only (~3 min)
cargo bench --bench memory            # allocations and peak memory
cargo bench -- fourfold               # filter on the scenario id
CYGV_BENCH_HEAVY=1 cargo bench        # add the high-degree scenarios
CYGV_BENCH_THREADS=1 cargo bench      # pin the worker count to cut noise
```

The high-degree scenarios are gated because criterion has to sample each of them
ten or more times; the memory target runs everything once, so enabling them
there is cheap.

## Sample output

```
scenario                           peak alloc  total alloc       allocs     peak RSS   time (s)    results
threefold/deg30/gv-rational           1.5 MiB    104.3 MiB      3181788      7.3 MiB      0.735        368
fourfold/deg10/gw-float               8.4 MiB    219.7 MiB      1773060     18.0 MiB      0.398      14202
```

One thing the numbers already surface: `gw-float` on the fourfold is a large
outlier. At degree 20 it takes 260 s and 1.6 GiB peak, allocating 101 GiB over
$10^9$ allocations, and returns 601,274 invariants against 2,167 for
`gw-rational` — without an exact zero to compare against it appears to keep
every near-zero invariant. That is why the heavy tier caps the fourfold at
degree 15, and it looks like a worthwhile thing to look into separately.

## Testing

- `cargo bench` and `CYGV_BENCH_HEAVY=1 cargo bench` both run clean.
- `cargo test` and `prek -a` pass. No library code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)