### PR TITLE
ci: cache GMP and MPFR builds and enforce the lockfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,14 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-2022' && 'msys2 {0}' || 'bash' }}
+    env:
+      # These are the artifacts users actually install, so the wheels must be
+      # built from the committed lockfile rather than a fresh resolution.
+      # maturin's PEP 517 backend splits this into the args it passes to
+      # `maturin pep517 build-wheel`, which forwards cargo's `--locked`. It has
+      # to be repeated inside CIBW_ENVIRONMENT below to reach the container
+      # builds, and `build_sdist` ignores it, so the sdist job is unaffected.
+      MATURIN_PEP517_ARGS: --locked
     steps:
       - name: Set up MSYS2
         if: runner.os == 'Windows'
@@ -60,7 +68,7 @@ jobs:
         run: |
           pipx run cibuildwheel
         env:
-          CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'
+          CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always" MATURIN_PEP517_ARGS="--locked"'
           CIBW_BEFORE_BUILD: rustup show
           CIBW_BEFORE_BUILD_LINUX: >
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y &&

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,6 +27,8 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-2022' && 'msys2 {0}' || 'bash' }}
+    env:
+      CC: clang
     steps:
       - name: Set up MSYS2
         if: runner.os == 'Windows'
@@ -56,8 +58,20 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      # See the Rust workflow: this caches the compiled GMP and MPFR libraries,
+      # which is where nearly all of the build time goes. Their contents depend
+      # only on the target and the C compiler, so the whole matrix — and the Rust
+      # workflow — share a single key per OS.
+      - name: Point gmp-mpfr-sys at a cacheable directory
+        run: echo "GMP_MPFR_SYS_CACHE=${{ runner.temp }}/gmp-mpfr-sys" >> "$GITHUB_ENV"
+      - name: Cache GMP and MPFR builds
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/gmp-mpfr-sys
+          key: gmp-mpfr-sys-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: gmp-mpfr-sys-${{ matrix.os }}-
       - name: Pip install the package
-        run: CC=clang python -m pip install .[tests]
+        run: python -m pip install .[tests]
       - name: Run pytest
         run: |
           pytest -vv

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,6 +73,26 @@ jobs:
           path: ${{ runner.temp }}/gmp-mpfr-sys
           key: gmp-mpfr-sys-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: gmp-mpfr-sys-${{ matrix.os }}-
+      # Same hand-rolled cargo cache as the Rust workflow; see there for why it
+      # is not Swatinem/rust-cache and why the toolchain is in the key. This one
+      # covers the release-profile build that `pip install .` drives through
+      # maturin, which is what is left of the Windows job's runtime.
+      # See the Rust workflow: cache keys reject commas, which the MINGW64
+      # toolchain's version string contains.
+      - name: Record the toolchain for the cache key
+        run: echo "RUSTC_VERSION=$(rustc -V | tr -dc 'A-Za-z0-9.')" >> "$GITHUB_ENV"
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            target
+          # The three Python versions share a key: abi3 aside, pyo3 and cygv
+          # rebuild per interpreter, but every other dependency is shared, and
+          # only the first job to finish saves under a given key anyway.
+          key: cargo-release-${{ matrix.os }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-release-${{ matrix.os }}-${{ env.RUSTC_VERSION }}-
       - name: Pip install the package
         run: python -m pip install .[tests]
       - name: Run pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -93,8 +93,16 @@ jobs:
           # only the first job to finish saves under a given key anyway.
           key: cargo-release-${{ matrix.os }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: cargo-release-${{ matrix.os }}-${{ env.RUSTC_VERSION }}-
+      # Windows builds without isolation because MSYS2 has no maturin wheel on
+      # PyPI: pip would build the only build dependency from source, which took
+      # five minutes of every run while `mingw-w64-x86_64-python-maturin` sat
+      # installed and unused. deploy.yml skips isolation on Windows for the same
+      # reason. The tradeoff is that pip stops checking `build-system.requires`,
+      # so the maturin pacman ships has to keep satisfying `>=1.5,<2.0`. The
+      # other platforms get a maturin wheel in seconds and do not preinstall it,
+      # so they keep isolation.
       - name: Pip install the package
-        run: python -m pip install .[tests]
+        run: python -m pip install ${{ runner.os == 'Windows' && '--no-build-isolation' || '' }} .[tests]
       - name: Run pytest
         run: |
           pytest -vv

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,6 +29,9 @@ jobs:
         shell: ${{ matrix.os == 'windows-2022' && 'msys2 {0}' || 'bash' }}
     env:
       CC: clang
+      # `pip install .` drives cargo through maturin, which takes its cargo
+      # flags from this variable; the Rust workflow passes `--locked` directly.
+      MATURIN_PEP517_ARGS: --locked
     steps:
       - name: Set up MSYS2
         if: runner.os == 'Windows'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,13 +64,34 @@ jobs:
           path: ${{ runner.temp }}/gmp-mpfr-sys
           key: gmp-mpfr-sys-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: gmp-mpfr-sys-${{ matrix.os }}-
-      # Caches the registry and target dir. Skipped on Windows: the action runs
-      # `cargo` from node rather than through the msys2 shell, so it would key
-      # the cache on the runner's preinstalled MSVC toolchain instead of the
-      # MINGW64 one that actually builds here.
+      # Caches the registry and the target dir. Done by hand rather than with
+      # Swatinem/rust-cache because that action runs `cargo` from node instead
+      # of through the msys2 shell, so on Windows it would key the cache on the
+      # runner's preinstalled MSVC toolchain rather than the MINGW64 one that
+      # actually builds here.
+      #
+      # The toolchain has to be part of the key: an upgrade invalidates every
+      # artifact in `target/`, and since actions/cache skips saving whenever the
+      # primary key hits exactly, a stale entry would otherwise never be
+      # replaced. It is in the restore-key prefix too, so a new toolchain starts
+      # clean instead of restoring artifacts it cannot use.
+      # Keep only alphanumerics and dots: cache keys reject commas, and the
+      # MINGW64 toolchain reports `rustc 1.x.0 (hash date) (Rev1, Built by
+      # MSYS2 project)`.
+      - name: Record the toolchain for the cache key
+        run: echo "RUSTC_VERSION=$(rustc -V | tr -dc 'A-Za-z0-9.')" >> "$GITHUB_ENV"
       - name: Cache cargo registry and build artifacts
-        if: runner.os != 'Windows'
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            target
+          # `dev-` because this workflow builds the dev profile while the Python
+          # workflow builds release; sharing a key would mean whichever saved
+          # first left the other restoring a target dir without its profile.
+          key: cargo-dev-${{ matrix.os }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-dev-${{ matrix.os }}-${{ env.RUSTC_VERSION }}-
       # `--locked` fails the build rather than silently re-resolving when
       # `Cargo.lock` is out of date with `Cargo.toml`. Without it a manifest
       # change committed without its lockfile update would be tested against a

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,11 @@ jobs:
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-2022' && 'msys2 {0}' || 'bash' }}
+    env:
+      # `gmp-mpfr-sys` keys its build cache on the compiler, so this has to be
+      # set for the whole job: a cargo step that ran without it would miss the
+      # cache and build GMP and MPFR from source again.
+      CC: clang
     steps:
       - name: Set up MSYS2
         if: runner.os == 'Windows'
@@ -45,8 +50,29 @@ jobs:
             curl
       - name: Check out repo
         uses: actions/checkout@v7
+      # `rug` builds GMP and MPFR from source, which dominates the job (~13 min
+      # on Windows). `gmp-mpfr-sys` keeps the built libraries in the directory
+      # named by GMP_MPFR_SYS_CACHE, keyed internally by version, target and
+      # compiler, so restoring it turns the build into a file copy. The variable
+      # goes through GITHUB_ENV because the `runner` context is not available in
+      # a job-level `env` block.
+      - name: Point gmp-mpfr-sys at a cacheable directory
+        run: echo "GMP_MPFR_SYS_CACHE=${{ runner.temp }}/gmp-mpfr-sys" >> "$GITHUB_ENV"
+      - name: Cache GMP and MPFR builds
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/gmp-mpfr-sys
+          key: gmp-mpfr-sys-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: gmp-mpfr-sys-${{ matrix.os }}-
+      # Caches the registry and target dir. Skipped on Windows: the action runs
+      # `cargo` from node rather than through the msys2 shell, so it would key
+      # the cache on the runner's preinstalled MSVC toolchain instead of the
+      # MINGW64 one that actually builds here.
+      - name: Cache cargo registry and build artifacts
+        if: runner.os != 'Windows'
+        uses: Swatinem/rust-cache@v2
       - name: Build
-        run: CC=clang cargo build --verbose
+        run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,10 +71,15 @@ jobs:
       - name: Cache cargo registry and build artifacts
         if: runner.os != 'Windows'
         uses: Swatinem/rust-cache@v2
+      # `--locked` fails the build rather than silently re-resolving when
+      # `Cargo.lock` is out of date with `Cargo.toml`. Without it a manifest
+      # change committed without its lockfile update would be tested against a
+      # dependency set that is in nobody's tree, and the cache key above —
+      # which hashes the committed lockfile — would not describe what was built.
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --locked --verbose
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --locked --verbose
 
   check-rust:
     name: Check Rust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,13 @@ never be replaced. And the two workflows use different key prefixes — `cargo-d
 release; sharing a key would leave whichever job saved second restoring a `target/` with the wrong
 profile in it. Nothing prunes these entries, so they are considerably larger than the GMP one.
 
+The Windows Python job additionally installs with `--no-build-isolation`. maturin — the only entry
+in `build-system.requires` — has no MINGW64 wheel on PyPI, so pip's isolated build environment
+compiled it from source on every run, five minutes of work to duplicate the
+`mingw-w64-x86_64-python-maturin` that pacman had already installed. `deploy.yml` skips isolation
+on Windows for the same reason. The catch is that pip no longer enforces `build-system.requires`
+there, so the version pacman ships has to keep satisfying `>=1.5,<2.0` on its own.
+
 `[tool.uv] cache-keys` in `pyproject.toml` lists `src/**/*.rs`; without it uv would not rebuild the
 editable extension when only Rust sources change, and `uv run pytest` would test a stale build.
 `uv.lock` is gitignored — it pins only the dev environment and does not affect consumers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,19 @@ Two consequences worth remembering: `CC` must be set identically for every cargo
 job (a step that drops it looks under a different `CC-*` subdirectory and rebuilds from source),
 and the cache does not depend on the cargo profile, so the whole Python matrix and the Rust
 workflow share one key per OS — which is also why the key hashes `Cargo.lock` rather than anything
-build-specific. The Rust workflow additionally uses `Swatinem/rust-cache` for the
-registry and `target/`, but not on Windows — that action invokes `cargo` outside the msys2 shell,
-where the MINGW64 toolchain is not on `PATH`.
+build-specific.
+
+Both workflows separately cache `~/.cargo/registry` and `target/` with a hand-rolled
+`actions/cache` step rather than `Swatinem/rust-cache`, because that action runs `cargo` from node
+instead of through the msys2 shell and would therefore key the Windows cache on the runner's
+preinstalled MSVC toolchain rather than the MINGW64 one doing the build. Two things that action
+handled for us have to be done explicitly. The toolchain version goes in the key (and in the
+restore-key prefix): a compiler upgrade invalidates every artifact in `target/`, and because
+`actions/cache` skips saving whenever the primary key hits exactly, a stale entry would otherwise
+never be replaced. And the two workflows use different key prefixes — `cargo-dev-` and
+`cargo-release-` — because the Rust workflow builds the dev profile and the Python workflow builds
+release; sharing a key would leave whichever job saved second restoring a `target/` with the wrong
+profile in it. Nothing prunes these entries, so they are considerably larger than the GMP one.
 
 `[tool.uv] cache-keys` in `pyproject.toml` lists `src/**/*.rs`; without it uv would not rebuild the
 editable extension when only Rust sources change, and `uv run pytest` would test a stale build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,13 @@ dependency that drifted underneath them. The cost is that CI no longer continuou
 newest semver-compatible dependencies; the monthly grouped cargo Dependabot PR is what covers that,
 so it should be treated as a real test run rather than rubber-stamped.
 
+Every workflow that compiles Rust enforces the lockfile, so a manifest change committed without its
+lockfile update fails instead of silently re-resolving. The Rust workflow passes `--locked` to
+cargo directly; the Python and deploy workflows reach cargo through maturin and set
+`MATURIN_PEP517_ARGS=--locked` instead. Two wrinkles there: cibuildwheel needs it repeated inside
+`CIBW_ENVIRONMENT` to reach the container builds, and maturin's `build_sdist` never reads the
+variable, so the sdist job is unaffected by it.
+
 PR titles must follow conventional commits (enforced by `.github/workflows/pr_title.yml`).
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,19 @@ toolchain plus `m4` and `make` (`configure: error: No usable m4 in $PATH` means 
 CI sets `CC=clang` on all platforms; locally the default compiler is usually fine, and forcing
 `CC=clang` fails outright if clang is not installed. Windows builds go through MSYS2/MINGW64.
 
+That source build dominates CI (~13 min on Windows, where it used to be more than half the job),
+so both CI workflows cache it. `gmp-mpfr-sys` keeps the built libraries in the directory named by
+`GMP_MPFR_SYS_CACHE`, under a subdirectory keyed by version, target triple, `CC` and `CFLAGS`, and
+copies them back instead of rebuilding — about 3.5 MB, and a ~240 s build becomes ~8 s. The
+workflows point that variable at `$RUNNER_TEMP/gmp-mpfr-sys` and restore it with `actions/cache`.
+Two consequences worth remembering: `CC` must be set identically for every cargo invocation in a
+job (a step that drops it looks under a different `CC-*` subdirectory and rebuilds from source),
+and the cache does not depend on the cargo profile, so the whole Python matrix and the Rust
+workflow share one key per OS — which is also why the key hashes `Cargo.lock` rather than anything
+build-specific. The Rust workflow additionally uses `Swatinem/rust-cache` for the
+registry and `target/`, but not on Windows — that action invokes `cargo` outside the msys2 shell,
+where the MINGW64 toolchain is not on `PATH`.
+
 `[tool.uv] cache-keys` in `pyproject.toml` lists `src/**/*.rs`; without it uv would not rebuild the
 editable extension when only Rust sources change, and `uv run pytest` would test a stale build.
 `uv.lock` is gitignored — it pins only the dev environment and does not affect consumers.
@@ -147,7 +160,11 @@ both sides feed the same counters. GMP passes the block size back on free and re
 bookkeeping headers are needed. The hooks must be installed before any GMP object exists, which is
 why it happens first thing in `main`. Each scenario then runs in a child process (`--run <id>`,
 spawned by the parent), so peaks do not leak between scenarios and `VmHWM` reflects one scenario
-only. The `gmp-mpfr-sys` dev-dependency must stay compatible with the version `rug` links against.
+only. The `gmp-mpfr-sys` dev-dependency must stay compatible with the version `rug` links against,
+and must request exactly the features `rug` does (`default-features = false`, `mpc` and `mpfr`).
+Cargo fingerprints feature *names*, not what they expand to, so enabling `default` here — which
+resolves to the very same two features — splits it into a second build unit and compiles GMP and
+MPFR from source a second time, doubling every cold CI build.
 
 The high-degree scenarios are gated behind `CYGV_BENCH_HEAVY` because criterion has to run each of
 them ten or more times; the memory target runs everything once, so enabling them there is cheap.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,14 @@ features = ["abi3-py310"]
 criterion = { version = "0.8.1", features = ["html_reports"] }
 # Only used by the memory benchmark, to route GMP/MPFR allocations through a
 # counting allocator. Must stay compatible with the version `rug` links against.
-gmp-mpfr-sys = "1.7"
+# The feature list must match `rug`'s exactly (it depends on this crate with
+# `default-features = false`): cargo fingerprints feature *names*, so enabling
+# `default` here — even though it expands to the same set — would create a second
+# build unit and rebuild GMP and MPFR from source a second time.
+gmp-mpfr-sys = { version = "1.7", default-features = false, features = [
+  "mpc",
+  "mpfr",
+] }
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Windows was the entire critical path — the Rust job spent 27 of its 29 minutes building GMP and MPFR, the Python job 19 of 21, while every other platform finished in 2–9 minutes.

| | Before | After |
|---|---|---|
| **Rust CI** | 28m30s | **2m21s** |
| └ windows-2022 | 29m19s | 2m11s |
| └ linux / macos | 4–9m | 13–20s |
| **Python CI** | 21m02s | **3m04s** |
| └ windows-2022 | 21m05s | 2m55s |

Five independent problems, each measured rather than assumed.

### 1. It was building GMP and MPFR twice per job

The `gmp-mpfr-sys` dev-dependency added for the memory benchmark in #76 was written as `gmp-mpfr-sys = "1.7"`, enabling the `default` feature. `rug` depends on the same crate with `default-features = false, features = ["mpc", "mpfr"]`. Both resolve to the same two features, but cargo fingerprints feature *names* rather than what they expand to, so it built two units and compiled GMP and MPFR from source twice — `cargo test` redid everything `cargo build` had just done.

Rust CI on `main` ran 13–15 minutes historically and jumped to 28.5 minutes on the run that merged #76. Requesting the same features as `rug` collapses them into one unit: **`Run tests` on Windows went from 13m54s to 35s**, visible before any cache existed.

### 2. GMP and MPFR were rebuilt every run

`gmp-mpfr-sys` keeps its built libraries in the directory named by `GMP_MPFR_SYS_CACHE`, keyed internally by version, target triple, `CC` and `CFLAGS`, and copies them back instead of rebuilding. Both workflows now restore that with `actions/cache`. Locally a 238 s cold build becomes 8.4 s for 3.5 MB of cache; **on Windows the `Build` step went 12m42s → 30s**.

`CC` moved to a job-level `env` for this: `cargo build` ran with `CC=clang` and `cargo test` without it, which would have put them in different `CC-*` subdirectories and rebuilt anyway. The cache is profile-independent, so the whole Python matrix and the Rust workflow share one key per OS — confirmed in practice, Python CI's ten jobs add no entries of their own.

### 3. Nothing cached the cargo registry or target dir on Windows

`Swatinem/rust-cache` runs `cargo` from node rather than through the msys2 shell, so on Windows it would key on the runner's preinstalled MSVC toolchain instead of the MINGW64 one doing the build. Replaced with a hand-rolled `actions/cache` covering all four platforms in both workflows. **Windows `Build` 30s → 10s; the Linux and macOS jobs also improved, 26–29s → 13–20s.**

Two things that action did implicitly are now explicit:

- **The toolchain is in the key**, and in the restore-key prefix. A compiler upgrade invalidates every artifact in `target/`, and `actions/cache` skips saving on an exact primary-key hit, so a stale entry would otherwise never be replaced. Not hypothetical: macOS runners are on rustc 1.96.0 while the Ubuntu ones are on 1.97.1.
- **The workflows use different key prefixes**, `cargo-dev-` and `cargo-release-`, because Rust CI builds the dev profile and Python CI builds release. One shared key would leave whichever job saved second restoring a `target/` without its profile.

Cost: nothing prunes these entries the way rust-cache did. Debug entries are 214–239 MB, release 93–154 MB, so expect roughly 2.3 GB of steady-state cache on `main` against the 10 GB ceiling.

### 4. pip rebuilt maturin from source on every Windows run

maturin is the only entry in `build-system.requires` and has no MINGW64 wheel on PyPI, so pip's isolated build environment compiled it from source — **`Installing build dependencies` took 5m00s while the cygv wheel itself built in 13s** — duplicating the `mingw-w64-x86_64-python-maturin` the job already installs via pacman. `deploy.yml` has always skipped isolation on Windows for this reason.

Windows now installs with `--no-build-isolation`: **`Pip install the package` 5m26s → 36s**. Other platforms keep isolation, since they get a maturin wheel in seconds and do not preinstall it. The tradeoff is that pip no longer enforces `build-system.requires` there, so the maturin pacman ships has to keep satisfying `>=1.5,<2.0`.

### 5. Nothing enforced the lockfile

Possible only now that #78 tracks `Cargo.lock`. Every workflow that compiles Rust fails on a manifest committed without its lockfile update instead of silently re-resolving:

- **`rust.yml`** passes `--locked` to cargo directly. Verified both directions — passes on the current tree, and a dependency bump without regenerating the lockfile fails with `cannot update the lock file ... because --locked was passed`.
- **`deploy.yml`** matters most: those wheels are what users install, and nothing previously guaranteed they came from the committed lockfile. It reaches cargo through maturin, so it sets `MATURIN_PEP517_ARGS=--locked`, repeated inside `CIBW_ENVIRONMENT` because cibuildwheel does not forward the ambient environment into its containers. Verified by a `workflow_dispatch` run: 4/4 invocations on each Linux runner, 2/2 on macOS, 1/1 on Windows.
- **`python.yml`** likewise, largely redundant with `rust.yml` but keeps every cargo invocation consistent.

maturin's `build_sdist` never reads `MATURIN_PEP517_ARGS`, so the sdist job is unaffected.

### Notes

- `msys2/setup-msys2` already caches by default. At ~1m20s–1m50s it is now about two thirds of each Windows job and is the floor for both workflows.
- The same `Cargo.lock` hashes differently on Windows, because `core.autocrlf=true` on GitHub's images makes `actions/checkout` write CRLF. Harmless — the key includes `matrix.os`, so each hash is stable in its own namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
