### PR TITLE
fix: return errors instead of panicking on failure paths

### DIFF
--- a/src/instanton.rs
+++ b/src/instanton.rs
@@ -173,7 +173,11 @@ fn compute_expalpha_thread<T>(
             }
             Err(e) => Err(e),
         };
-        tx.send((t, p)).unwrap();
+        // The receiver hangs up early when another worker reports an error, so a
+        // failed send just means that there is nothing left to do.
+        if tx.send((t, p)).is_err() {
+            break;
+        }
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -752,6 +752,14 @@ min_points: 20
             load_one(&THREEFOLD.replace("[0, 1, 1, -1]", "[0, 1, 1, -1], [1, 0, 1, 2]")),
             Err(IoError::InvalidField { field, .. }) if field == "intnums"
         ));
+        // Intersection numbers that are all zero must be rejected, not panic.
+        assert!(matches!(
+            load_one(&THREEFOLD.replace(
+                "intnums: [[0, 0, 0, 2], [0, 0, 1, 1], [0, 1, 1, -1], [1, 1, 1, 5]]",
+                "intnums: [[0, 0, 0, 0], [0, 0, 1, 0]]",
+            )),
+            Err(IoError::InvalidField { field, .. }) if field == "intnums"
+        ));
         assert!(Input::load_all("generators: [[1]], bad").is_err());
     }
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -47,6 +47,11 @@ pub fn process_int_nums(
             return Err(MiscError::RepeatedIdxIntNums);
         }
     }
+    // All of the input intersection numbers may have been zero, in which case the
+    // maxima taken below would panic.
+    if intnum_res.is_empty() {
+        return Err(MiscError::EmptyIntNums);
+    }
     let n_indices = if is_threefold {
         intnum_idxpairs.iter().map(|p| p.1).max().unwrap()
     } else {
@@ -76,5 +81,14 @@ mod tests {
         assert_eq!(intnum_dict.len(), 3);
         assert_eq!(intnum_idxpairs.len(), 3);
         assert_eq!(n_indices, 1);
+    }
+
+    #[test]
+    fn test_all_zero_int_nums() {
+        let intnums = HashMap::from([((0, 1, 1), 0), ((0, 1, 2), 0)]);
+        for is_threefold in [true, false] {
+            let result = process_int_nums(intnums.clone(), is_threefold);
+            assert!(matches!(result, Err(MiscError::EmptyIntNums)));
+        }
     }
 }

--- a/src/polynomial/error.rs
+++ b/src/polynomial/error.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 /// An error enum for polynomial errors.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PolynomialError {
     ZeroConstantTermError,
     NonZeroConstantTermError,

--- a/src/series_inversion.rs
+++ b/src/series_inversion.rs
@@ -141,7 +141,11 @@ fn compute_li2qn_thread<T, const FIND_GV: bool>(
         } else {
             Ok(tmp_qn.clone(np))
         };
-        tx.send((t, tmp_qn, tmp_li2qn)).unwrap();
+        // The receiver hangs up early when another worker reports an error, so a
+        // failed send just means that there is nothing left to do.
+        if tx.send((t, tmp_qn, tmp_li2qn)).is_err() {
+            break;
+        }
     }
 }
 
@@ -335,6 +339,9 @@ where
                 }
             }
         });
+        if let Some(e) = error {
+            return Err(e.into());
+        }
         // Now we update the cache of previous qN
         previous_qn.pop_front();
         previous_qn_ind.pop_front();

--- a/src/series_inversion/error.rs
+++ b/src/series_inversion/error.rs
@@ -1,19 +1,29 @@
 //! A module for errors that can happen in series inversions.
 
+use crate::polynomial::error::PolynomialError;
 use core::fmt;
 
 /// An error structure for semigroup errors.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SeriesInversionError {
     NonIntegerGVError,
+    PolynomialError(PolynomialError),
 }
 
 /// Implement Display trait for SeriesInversionError.
 impl fmt::Display for SeriesInversionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let message = match self {
-            SeriesInversionError::NonIntegerGVError => "A non-integer GV invariant was found",
-        };
-        write!(f, "{message}")
+        match self {
+            SeriesInversionError::NonIntegerGVError => {
+                write!(f, "A non-integer GV invariant was found")
+            }
+            SeriesInversionError::PolynomialError(e) => e.fmt(f),
+        }
+    }
+}
+
+impl From<PolynomialError> for SeriesInversionError {
+    fn from(e: PolynomialError) -> Self {
+        SeriesInversionError::PolynomialError(e)
     }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Three failure paths aborted the process instead of surfacing an error:

- **`process_int_nums` panicked when every intersection number was zero.** The canonicalization loop skips zero values, so an input like `intnums: [[0, 0, 0, 0]]` left the maps empty and the `.max().unwrap()` panicked — reachable straight through the CLI, whose eager validation in `Input::from_yaml` exists precisely to report this kind of thing gracefully. It now returns `MiscError::EmptyIntNums` (whose message already reads "there must be at least one nonzero intersection number").
- **Worker channel sends turned error returns into panics.** In `compute_expalpha_thread` and `compute_li2qn_thread`, the receive loop `break`s when a worker reports an error, dropping the receiver while other workers still have pending `tx.send(...).unwrap()` calls. Those sends then failed, and `thread::scope` propagated the worker panic — so the carefully constructed `Err` paths were (nondeterministically) unreachable. Workers now treat a failed send as "receiver hung up, stop working".
- **`invert_series` swallowed `li_2` errors.** The `error` local was assigned in the receive loop but never read after the thread scope. It is now propagated via a new `SeriesInversionError::PolynomialError` variant (with a `From` impl; `PolynomialError` gains `PartialEq` to keep the derive).

## Test plan

- New unit test `misc::tests::test_all_zero_int_nums` and a new case in `io::tests::test_parse_errors`.
- Verified the CLI repro end to end: the input above now prints `Error: invalid value for the field "intnums": ...` and exits 1 instead of panicking.
- `cargo test --locked`, `cargo clippy --all-targets --locked`, and `prek -a` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)