### PR TITLE
fix: assorted latent bugs in prettyprint, pow, and the Python bindings

### DIFF
--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -371,13 +371,24 @@ where
         let invert = n < 0;
         let mut n = n.unsigned_abs();
         let mut tmp_poly = if invert {
+            // The reciprocal requires a nonzero constant term, so its minimum degree
+            // is zero and no truncation is possible before the multiplications.
             let tmp_poly2 = self.recipr(poly_props, coeff_pool)?;
-            let tmp_poly3 =
-                tmp_poly2.truncated(max_deg - (n - 1) * min_deg, poly_props, coeff_pool);
+            let tmp_poly3 = tmp_poly2.truncated(max_deg, poly_props, coeff_pool);
             tmp_poly2.drop(coeff_pool);
             tmp_poly3
         } else {
-            self.truncated(max_deg - (n - 1) * min_deg, poly_props, coeff_pool)
+            // When the minimum degree of the result exceeds the maximum degree of
+            // the semigroup, the truncated result is the zero polynomial. Computing
+            // the truncation degree naively would underflow in that case.
+            let Some(trunc_deg) = (n - 1)
+                .checked_mul(min_deg)
+                .and_then(|d| max_deg.checked_sub(d))
+            else {
+                res.drop(coeff_pool);
+                return Ok(Self::new());
+            };
+            self.truncated(trunc_deg, poly_props, coeff_pool)
         };
         loop {
             if !n.is_multiple_of(2) {
@@ -891,6 +902,29 @@ mod tests {
         let p_3 = p.pow(3, &poly_props, &mut coeff_pool).unwrap();
         let p_3_res = p.mul(&p_2, &poly_props, &mut coeff_pool);
         assert_eq!(p_3, p_3_res);
+    }
+
+    #[test]
+    fn test_pow_truncates_to_zero() {
+        let tmp_rational = Rational::new();
+        let semigroup = example_semigroup();
+        let poly_props = PolynomialProperties::new(&semigroup, &tmp_rational);
+        let mut coeff_pool = NumberPool::new(tmp_rational.clone(), 100);
+
+        // The semigroup has maximum degree two, so any power beyond the second of a
+        // polynomial with minimum degree one truncates to zero.
+        let p = polynomial!(
+            tmp_rational,
+            (1, 2), // 2*x
+            (2, 3)  // 3*y
+        );
+        let p_4 = p.pow(4, &poly_props, &mut coeff_pool).unwrap();
+        assert_eq!(p_4, Polynomial::new());
+
+        // Powers of the zero polynomial stay zero.
+        let p_zero: Polynomial<Rational> = Polynomial::new();
+        let p_zero_2 = p_zero.pow(2, &poly_props, &mut coeff_pool).unwrap();
+        assert_eq!(p_zero_2, Polynomial::new());
     }
 
     #[test]

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -372,11 +372,8 @@ where
         let mut n = n.unsigned_abs();
         let mut tmp_poly = if invert {
             // The reciprocal requires a nonzero constant term, so its minimum degree
-            // is zero and no truncation is possible before the multiplications.
-            let tmp_poly2 = self.recipr(poly_props, coeff_pool)?;
-            let tmp_poly3 = tmp_poly2.truncated(max_deg, poly_props, coeff_pool);
-            tmp_poly2.drop(coeff_pool);
-            tmp_poly3
+            // is zero and no up-front truncation is possible.
+            self.recipr(poly_props, coeff_pool)?
         } else {
             // When the minimum degree of the result exceeds the maximum degree of
             // the semigroup, the truncated result is the zero polynomial. Computing

--- a/src/polynomial/prettyprint.rs
+++ b/src/polynomial/prettyprint.rs
@@ -15,7 +15,7 @@ pub struct PrettyPrintPolynomial<'a, T> {
 impl<'a, T: fmt::Display> fmt::Display for PrettyPrintPolynomial<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let variables = ["x", "y", "z", "w", "v", "u"];
-        let n_variables = self.properties.semigroup.elements.ncols();
+        let n_variables = self.properties.semigroup.elements.nrows();
         let mut message = String::new();
         for (i_ind, i) in self.polynomial.nonzero.iter().enumerate() {
             let coeff = self.polynomial.coeffs.get(i).unwrap();
@@ -45,5 +45,66 @@ impl<'a, T: fmt::Display> fmt::Display for PrettyPrintPolynomial<'a, T> {
             }
         }
         write!(f, "{message}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pool::NumberPool;
+    use crate::semigroup::Semigroup;
+    use nalgebra::{DMatrix, DVector, RowDVector};
+    use rug::{Assign, Rational};
+
+    #[test]
+    fn test_display_named_variables() {
+        // Two variables, but more than six monomials: the variables must still be
+        // printed with their names, since the count is the number of rows.
+        #[rustfmt::skip]
+        let elements = DMatrix::from_column_slice(2, 7,
+            &[
+                0, 0,
+                1, 0,
+                0, 1,
+                2, 0,
+                1, 1,
+                0, 2,
+                3, 0,
+            ]
+        );
+        let grading_vector = RowDVector::from_row_slice(&[1, 1]);
+        let sg = Semigroup::from_data(elements, grading_vector).unwrap();
+        let tmp_rational = Rational::new();
+        let poly_props = PolynomialProperties::new(&sg, &tmp_rational);
+        let mut coeff_pool = NumberPool::new(tmp_rational.clone(), 10);
+
+        let index_of = |monomial: &[i32]| {
+            let monomial = DVector::from_column_slice(monomial);
+            poly_props.monomial_map[&monomial.as_view()]
+        };
+        let display = |p: &Polynomial<Rational>| {
+            format!(
+                "{}",
+                PrettyPrintPolynomial {
+                    polynomial: p,
+                    properties: &poly_props,
+                }
+            )
+        };
+
+        let mut p = Polynomial::one(&mut coeff_pool);
+        assert_eq!(display(&p), "1");
+
+        let mut coeff = coeff_pool.pop();
+        coeff.assign(2);
+        p.coeffs.insert(index_of(&[1, 1]), coeff);
+        p.nonzero.push(index_of(&[1, 1]));
+        assert_eq!(display(&p), "1 + 2*x*y");
+
+        let mut coeff = coeff_pool.pop();
+        coeff.assign(3);
+        p.coeffs.insert(index_of(&[3, 0]), coeff);
+        p.nonzero.push(index_of(&[3, 0]));
+        assert_eq!(display(&p), "1 + 2*x*y + 3*x^3");
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,8 +1,11 @@
 use crate::hkty::compute_gvgw_strings;
-use ctrlc;
 use nalgebra::{DMatrix, DVector, RowDVector};
 use pyo3::prelude::*;
 use std::collections::HashMap;
+use std::sync::Once;
+
+/// Installing a ctrl-c handler can only be done once per process, so guard it.
+static CTRLC_HANDLER: Once = Once::new();
 
 fn to_matrix(m: Vec<Vec<i32>>) -> DMatrix<i32> {
     let n_cols = m.len();
@@ -63,7 +66,9 @@ pub fn compute_gvgw(
     pool_size: usize,
     prec: Option<u32>,
 ) -> PyResult<Vec<((Vec<i32>, usize), String)>> {
-    ctrlc::set_handler(|| std::process::exit(1)).unwrap();
+    CTRLC_HANDLER.call_once(|| {
+        ctrlc::set_handler(|| std::process::exit(1)).expect("failed to install ctrl-c handler");
+    });
     let generators = to_matrix(generators);
     let grading_vector = to_rowvector(grading_vector);
     let q = to_matrix(q);

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -323,9 +323,10 @@ fn trim_by_max_deg(
 fn find_generators(elements: &DMatrix<i32>) -> DMatrix<i32> {
     // TODO: Need to check if it is worth to do this in parallel.
 
-    // TODO: Need to check if this is reasonable. For the original code it was
-    // 5, but that was probably too high.
-    let max_sum_elements = 3;
+    // Elements that are the sum of up to this many other elements are discarded.
+    // TODO: Need to check if this is reasonable. The original code checked sums
+    // of up to 4 elements, but that was probably too high.
+    let max_sum_elements = 2;
 
     let dim = elements.nrows();
     let zero_vec = DVector::<i32>::zeros(dim);
@@ -336,7 +337,7 @@ fn find_generators(elements: &DMatrix<i32>) -> DMatrix<i32> {
 
     let mut to_remove = HashSet::new();
 
-    for n in 2..max_sum_elements {
+    for n in 2..=max_sum_elements {
         for v in generators.iter().combinations_with_replacement(n) {
             tmp_vec.copy_from(&zero_vec);
             for c in v.into_iter() {

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -324,9 +324,9 @@ fn find_generators(elements: &DMatrix<i32>) -> DMatrix<i32> {
     // TODO: Need to check if it is worth to do this in parallel.
 
     // Elements that are the sum of up to this many other elements are discarded.
-    // TODO: Need to check if this is reasonable. The original code checked sums
-    // of up to 4 elements, but that was probably too high.
-    let max_sum_elements = 2;
+    // TODO: Need to check if this is reasonable. The original code used sums of
+    // up to 4 elements, but that was probably too high.
+    let max_sum_elements = 3;
 
     let dim = elements.nrows();
     let zero_vec = DVector::<i32>::zeros(dim);


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Four small, latent bugs found during a code review:

- **`PrettyPrintPolynomial` counted variables wrong** (`src/polynomial/prettyprint.rs`): `n_variables` was `elements.ncols()` — the number of *monomials* — instead of `nrows()`. The named-variable branch (`x`, `y`, …) therefore almost never triggered, and a semigroup with ≤ 6 elements but > 6 rows would panic with an out-of-bounds index. Added a regression test with 2 variables and 7 monomials.
- **`Polynomial::pow` underflowed `u32` when the power truncates to zero**: `max_deg - (n - 1) * min_deg` panics in debug builds (wraps in release) whenever `(n-1)·min_deg > max_deg` — e.g. any positive-minimum-degree polynomial raised to a high enough power, or the zero polynomial squared (its `min_degree` is `max_degree + 1`). The truncation degree is now computed with checked arithmetic and the zero polynomial is returned when it truncates away entirely. The reciprocal branch is unaffected (its minimum degree is necessarily zero) but was restructured so a zero-constant-term error is still reported first.
- **`_compute_gvgw` panicked when called twice in one process** (`src/python.rs`): `ctrlc::set_handler(...).unwrap()` ran on every call, and `ctrlc` errors on re-registration. The public Python wrapper masks this by spawning a fresh subprocess per call, but the raw binding is importable directly. The handler is now installed via `std::sync::Once`.
- **`find_generators` never checked sums of three elements** (`src/semigroup.rs`): the exclusive loop `for n in 2..max_sum_elements` with `max_sum_elements = 3` only ever ran `n = 2`, so the intended three-element pass never executed. The loop is now inclusive with the constant set to 3, so sums of two and three elements are both checked. This is a behavior change: generator sets can come out smaller (still correct — only provably redundant generators are removed), at the cost of an O(m³) pass over the input generator list.

## Test plan

- New tests: `prettyprint::tests::test_display_named_variables`, `polynomial::tests::test_pow_truncates_to_zero` (the latter panics on the previous code in debug builds).
- `cargo test --locked`, `cargo clippy --all-targets --locked`, and `prek -a` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
