### PR TITLE
perf: reduce allocations and redundant work in hot paths

### DIFF
--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -52,6 +52,60 @@ where
     }
 }
 
+/// A cache of generalized harmonic numbers $H_{n,m}$ for a fixed $m$.
+///
+/// The values are computed incrementally, so requesting $H_{n,m}$ only costs
+/// one reciprocal and one addition for each $n$ beyond the largest one
+/// requested so far. This is much cheaper than [`harmonic`] when the same
+/// values are needed repeatedly.
+///
+/// # Examples
+///
+/// ```
+/// use rug::Rational;
+/// use cygv::factorial::HarmonicCache;
+///
+/// let mut cache = HarmonicCache::new(2, &Rational::new());
+///
+/// assert_eq!(*cache.get(10), Rational::from((1_968_329, 1_270_080)));
+/// assert_eq!(*cache.get(1), Rational::from(1));
+/// ```
+pub struct HarmonicCache<T> {
+    m: u32,
+    values: Vec<T>,
+    tmp_var: T,
+}
+
+impl<T> HarmonicCache<T>
+where
+    T: Clone + RecipMut + Assign<u64> + for<'a> AddAssign<&'a T>,
+{
+    /// Create a new cache for the power $m$, using a clonable template number.
+    pub fn new(m: u32, template_num: &T) -> Self {
+        let mut zero = template_num.clone();
+        zero.assign(0u64);
+        Self {
+            m,
+            values: vec![zero],
+            tmp_var: template_num.clone(),
+        }
+    }
+
+    /// Return $H_{n,m}$, extending the cache when needed.
+    pub fn get(&mut self, n: u32) -> &T {
+        let n = n as usize;
+        while self.values.len() <= n {
+            let i = self.values.len() as u64;
+            self.tmp_var.assign(i.pow(self.m));
+            self.tmp_var.recip_mut();
+            let mut next = self.values[self.values.len() - 1].clone();
+            next += &self.tmp_var;
+            self.values.push(next);
+        }
+        &self.values[n]
+    }
+}
+
 /// Efficienty computes products and fractions of factorials.
 ///
 /// # Examples
@@ -144,6 +198,30 @@ mod tests {
 
             assert_eq!(res_rat, true_rat);
             assert!((&res_float - &true_float).complete(512).abs() < 1e-100);
+        }
+    }
+
+    #[test]
+    fn test_harmonic_cache() {
+        let mut res_rat = Rational::new();
+        let mut tmp_rat = Rational::new();
+
+        let prec = 512;
+        let mut res_float = Float::new(prec);
+        let mut tmp_float = Float::new(prec);
+
+        for m in [1, 2] {
+            let mut cache_rat = HarmonicCache::new(m, &Rational::new());
+            let mut cache_float = HarmonicCache::new(m, &Float::new(prec));
+
+            // Request the values out of order to exercise the incremental fill.
+            for n in [10, 0, 3, 10, 25] {
+                harmonic(n, m, &mut res_rat, &mut tmp_rat);
+                harmonic(n, m, &mut res_float, &mut tmp_float);
+
+                assert_eq!(*cache_rat.get(n), res_rat);
+                assert!((cache_float.get(n) - &res_float).complete(512).abs() < 1e-100);
+            }
         }
     }
 

--- a/src/fundamental_period.rs
+++ b/src/fundamental_period.rs
@@ -2,7 +2,7 @@
 
 pub mod error;
 
-use crate::factorial::{factorial_prod, harmonic};
+use crate::factorial::{factorial_prod, HarmonicCache};
 use crate::polynomial::{coefficient::PolynomialCoeff, Polynomial};
 use crate::pool::NumberPool;
 use crate::semigroup::Semigroup;
@@ -53,9 +53,10 @@ fn compute_c_0neg<T>(
 {
     let mut a: Vec<_> = (0..q.ncols()).map(|_| template_var.clone()).collect();
     let mut tmp_num0 = template_var.clone();
-    let mut tmp_num1 = template_var.clone();
     let mut c0fact = template_var.clone();
     let mut tmp_final = template_var.clone();
+    let mut harmonic1 = HarmonicCache::new(1, template_var);
+    let mut harmonic2 = HarmonicCache::new(2, template_var);
     loop {
         let t;
         {
@@ -73,12 +74,12 @@ fn compute_c_0neg<T>(
         for (i, aa) in a.iter_mut().enumerate() {
             aa.assign(0);
             for (&qq0, &cdq0) in q0.column(i).iter().zip(curves_dot_q0.column(t).iter()) {
-                harmonic(cdq0 as u32, 1, &mut tmp_num0, &mut tmp_num1);
+                tmp_num0.assign(harmonic1.get(cdq0 as u32));
                 tmp_num0 *= qq0;
                 *aa += &tmp_num0;
             }
             for (&qq, &cdq) in q.column(i).iter().zip(curves_dot_q.column(t).iter()) {
-                harmonic(cdq as u32, 1, &mut tmp_num0, &mut tmp_num1);
+                tmp_num0.assign(harmonic1.get(cdq as u32));
                 tmp_num0 *= qq;
                 *aa -= &tmp_num0;
             }
@@ -95,7 +96,7 @@ fn compute_c_0neg<T>(
                 .zip(q0.column(bb).iter())
                 .zip(curves_dot_q0.column(t).iter())
             {
-                harmonic(cdq0 as u32, 2, &mut tmp_num0, &mut tmp_num1);
+                tmp_num0.assign(harmonic2.get(cdq0 as u32));
                 tmp_num0 *= q0a * q0b;
                 tmp_final -= &tmp_num0;
             }
@@ -105,7 +106,7 @@ fn compute_c_0neg<T>(
                 .zip(q.column(bb).iter())
                 .zip(curves_dot_q.column(t).iter())
             {
-                harmonic(cdq as u32, 2, &mut tmp_num0, &mut tmp_num1);
+                tmp_num0.assign(harmonic2.get(cdq as u32));
                 tmp_num0 *= qa * qb;
                 tmp_final += &tmp_num0;
             }
@@ -139,6 +140,7 @@ fn compute_c_1neg<T>(
     let mut tmp_num0 = template_var.clone();
     let mut tmp_num1 = template_var.clone();
     let mut tmp_final = template_var.clone();
+    let mut harmonic1 = HarmonicCache::new(1, template_var);
     loop {
         let t;
         {
@@ -178,21 +180,16 @@ fn compute_c_1neg<T>(
         for (i, aa) in a.iter_mut().enumerate() {
             aa.assign(0);
             for (&qq0, &cdq0) in q0.column(i).iter().zip(curves_dot_q0.column(t).iter()) {
-                harmonic(cdq0 as u32, 1, &mut tmp_num0, &mut tmp_num1);
+                tmp_num0.assign(harmonic1.get(cdq0 as u32));
                 tmp_num0 *= qq0;
                 *aa += &tmp_num0;
             }
             for (&qq, &cdq) in q.column(i).iter().zip(curves_dot_q.column(t).iter()) {
-                harmonic(
-                    if cdq.is_negative() {
-                        (-cdq - 1) as u32
-                    } else {
-                        cdq as u32
-                    },
-                    1,
-                    &mut tmp_num0,
-                    &mut tmp_num1,
-                );
+                tmp_num0.assign(harmonic1.get(if cdq.is_negative() {
+                    (-cdq - 1) as u32
+                } else {
+                    cdq as u32
+                }));
                 tmp_num0 *= qq;
                 *aa -= &tmp_num0;
             }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -9,6 +9,7 @@ use crate::pool::NumberPool;
 use coefficient::PolynomialCoeff;
 use core::ops::{DivAssign, MulAssign};
 use error::PolynomialError;
+use nalgebra::DVector;
 use properties::PolynomialProperties;
 use std::collections::HashMap;
 
@@ -201,7 +202,9 @@ where
         let mut deg1;
         let mut deg2;
         let max_deg = poly_props.semigroup.max_degree;
-        let mut tmp_vec;
+        // Reuse a single buffer for the monomial sums to avoid allocating in the
+        // innermost loop.
+        let mut tmp_vec = DVector::<i32>::zeros(poly_props.semigroup.elements.nrows());
         let (pshort, plong) = if self.nonzero.len() < rhs.nonzero.len() {
             (self, rhs)
         } else {
@@ -215,8 +218,8 @@ where
                 if deg1 + deg2 > max_deg {
                     break;
                 }
-                tmp_vec = poly_props.semigroup.elements.column(i)
-                    + poly_props.semigroup.elements.column(j);
+                tmp_vec.copy_from(&poly_props.semigroup.elements.column(i));
+                tmp_vec += poly_props.semigroup.elements.column(j);
                 let Some(mon) = poly_props.monomial_map.get(&tmp_vec.as_view()) else {
                     continue;
                 };
@@ -350,6 +353,8 @@ where
         }
         res.div_scalar_assign(&const_term);
         tmp_poly.drop(coeff_pool);
+        p0.drop(coeff_pool);
+        coeff_pool.push(const_term);
         Ok(res)
     }
 
@@ -425,6 +430,7 @@ where
             }
         }
         tmp_poly.drop(coeff_pool);
+        coeff_pool.push(tmp_var);
         Ok((res_pos, res_neg))
     }
 

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -122,10 +122,14 @@ impl Semigroup {
         let mut max_degree = 0;
         while elements_set.len() < min_elements {
             max_degree += 1;
+            // Raising the degree bound can let sums involving any existing element
+            // through, so each round starts from the full set, but afterwards only
+            // the frontier of newly found elements needs to be expanded.
+            let mut starting_elements = elements_set.clone();
             loop {
                 let new_elements = find_new_elements_until_max_deg(
                     &generators,
-                    &elements_set,
+                    &starting_elements,
                     &elements_set,
                     &grading_vector,
                     max_degree,
@@ -136,6 +140,7 @@ impl Semigroup {
                 for c in new_elements.iter() {
                     elements_set.insert(c.clone());
                 }
+                starting_elements = new_elements;
             }
         }
 


### PR DESCRIPTION
## Summary

Four independent hot-path improvements, none of which change results:

- **`Polynomial::mul` no longer allocates per coefficient pair.** `column(i) + column(j)` heap-allocated a fresh `DVector` in the innermost loop of the entire computation. It now reuses one buffer (`copy_from` + `+=`), the same owned-buffer lookup pattern already used in `series_inversion`.
- **Harmonic numbers are memoized.** The `compute_c_0neg`/`compute_c_1neg` workers called `harmonic(n, m)` — an O(n) big-number loop — for every (curve, index) combination, with the same small set of `n` values recurring constantly. A new incremental `factorial::HarmonicCache` (H_{n,m} = H_{n-1,m} + 1/n^m) fills each value exactly once per worker.
- **`recipr` and `exp_pos_neg` return their temporaries to the pool** instead of leaking them to the allocator, matching the pool discipline used everywhere else.
- **`with_min_elements` expands a frontier** instead of re-adding every generator to the entire element set on every closure pass, matching what `with_max_degree` already does.

## Measurements

Outputs are **bit-identical** to `main` on both bench models (verified with `diff` on the full CLI output).

Wall clock (release CLI, interleaved runs vs a `main` baseline binary):

| input | main | this PR |
|---|---|---|
| threefold, GV+GW, `min_points: 1500` | 12.7–13.9 s | 11.7–12.4 s (~5–8% faster) |
| fourfold, GW, `max_deg: 18` | 8.8–9.8 s | 8.5–8.9 s (~4–6% faster) |

`cargo bench --bench memory` at deg10 (gv-rational):

| scenario | allocs (main → PR) | total alloc (main → PR) |
|---|---|---|
| threefold | 33,336 → 18,662 (−44%) | 2.1 MiB → 1.9 MiB |
| fourfold | 450,005 → 326,949 (−27%) | 39.0 MiB → 33.3 MiB |

## Test plan

- New doctest and out-of-order unit test for `HarmonicCache` against the existing `harmonic` function.
- `cargo test --locked`, `cargo clippy --all-targets --locked`, and `prek -a` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
