### PR TITLE
refactor: deduplicate dispatch and cleanup code, simplify conversions

### DIFF
--- a/src/factorial.rs
+++ b/src/factorial.rs
@@ -52,7 +52,7 @@ where
     }
 }
 
-/// Efficienty computes products and fractions of factorials.
+/// Efficiently computes products and fractions of factorials.
 ///
 /// # Examples
 ///

--- a/src/fundamental_period.rs
+++ b/src/fundamental_period.rs
@@ -462,31 +462,15 @@ where
             }
         }
     });
-    for p in c1.iter_mut() {
-        p.nonzero = p.coeffs.keys().cloned().collect();
-        p.nonzero.sort_unstable();
-        p.clean_up(poly_props, coeff_pool);
-    }
-    for p in c2.values_mut() {
-        p.nonzero = p.coeffs.keys().cloned().collect();
-        p.nonzero.sort_unstable();
-        p.clean_up(poly_props, coeff_pool);
-    }
-
-    for p in c1.iter_mut() {
-        p.nonzero = p.coeffs.keys().cloned().collect();
-        p.nonzero.sort_unstable();
-    }
-    for p in c2.values_mut() {
-        p.nonzero = p.coeffs.keys().cloned().collect();
-        p.nonzero.sort_unstable();
-    }
-
     c0_inv.clean_up(poly_props, coeff_pool);
     for p in c1.iter_mut() {
+        p.nonzero = p.coeffs.keys().cloned().collect();
+        p.nonzero.sort_unstable();
         p.clean_up(poly_props, coeff_pool);
     }
     for p in c2.values_mut() {
+        p.nonzero = p.coeffs.keys().cloned().collect();
+        p.nonzero.sort_unstable();
         p.clean_up(poly_props, coeff_pool);
     }
 

--- a/src/hkty.rs
+++ b/src/hkty.rs
@@ -125,63 +125,38 @@ pub fn compute_gvgw_strings(
     pool_size: usize,
     prec: Option<u32>,
 ) -> Vec<((DVector<i32>, usize), String)> {
+    // Dispatch to the instantiation of `run_hkty` selected by the coefficient type
+    // and the two runtime flags. The flags and the argument list, which are the
+    // same for every variant, are each written only once here.
+    macro_rules! run_hkty_variant {
+        ($t:ty, $cutoff:expr) => {
+            match (find_gv, is_threefold) {
+                (true, true) => run_hkty_variant!(@call $t, $cutoff, true, true),
+                (true, false) => run_hkty_variant!(@call $t, $cutoff, true, false),
+                (false, true) => run_hkty_variant!(@call $t, $cutoff, false, true),
+                (false, false) => run_hkty_variant!(@call $t, $cutoff, false, false),
+            }
+        };
+        (@call $t:ty, $cutoff:expr, $find_gv:literal, $is_threefold:literal) => {
+            run_hkty::<$t, $find_gv, $is_threefold>(
+                generators,
+                grading_vector,
+                $cutoff,
+                max_deg,
+                min_points,
+                target_points,
+                q,
+                nefpart,
+                intnums,
+                n_threads,
+                pool_size,
+            )
+        };
+    }
     if let Some(n_bits) = prec {
         let mut zero_cutoff = Float::with_val(n_bits, 10);
         zero_cutoff.pow_assign(-(n_bits as i32) / 3);
-        let res = match (find_gv, is_threefold) {
-            (true, true) => run_hkty::<Float, true, true>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-            (false, true) => run_hkty::<Float, false, true>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-            (true, false) => run_hkty::<Float, true, false>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-            (false, false) => run_hkty::<Float, false, false>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-        };
+        let res = run_hkty_variant!(Float, zero_cutoff);
         res.into_iter()
             .map(|(k, gvgw)| {
                 (
@@ -196,60 +171,7 @@ pub fn compute_gvgw_strings(
             .collect()
     } else {
         let zero_cutoff = Rational::new();
-        let res = match (find_gv, is_threefold) {
-            (true, true) => run_hkty::<Rational, true, true>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-            (false, true) => run_hkty::<Rational, false, true>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-            (true, false) => run_hkty::<Rational, true, false>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-            (false, false) => run_hkty::<Rational, false, false>(
-                generators,
-                grading_vector,
-                zero_cutoff,
-                max_deg,
-                min_points,
-                target_points,
-                q,
-                nefpart,
-                intnums,
-                n_threads,
-                pool_size,
-            ),
-        };
+        let res = run_hkty_variant!(Rational, zero_cutoff);
         res.into_iter()
             .map(|(k, gvgw)| {
                 (

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 /// Process the input intersection numbers and find the relevant pairs of indices.
 /// For threefolds, the relevant pair of indices are simply all distinct (sorted) pairs.
-/// Othersize, the relevant pairs are the indices in the second and third columns,
+/// Otherwise, the relevant pairs are the indices in the second and third columns,
 /// since indices in the first column correspond to reference surfaces.
 #[allow(clippy::type_complexity)]
 pub fn process_int_nums(

--- a/src/polynomial/properties.rs
+++ b/src/polynomial/properties.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 /// A structure containing properties of a polynomial.
 ///
-/// This structure contains the data common to all polynomaials and is needed
+/// This structure contains the data common to all polynomials and is needed
 /// for most operations.
 #[derive(Clone, Debug)]
 pub struct PolynomialProperties<'a, T> {

--- a/src/python.rs
+++ b/src/python.rs
@@ -4,43 +4,20 @@ use nalgebra::{DMatrix, DVector, RowDVector};
 use pyo3::prelude::*;
 use std::collections::HashMap;
 
-fn to_matrix(m: Vec<Vec<i32>>) -> DMatrix<i32> {
-    let n_cols = m.len();
-    let n_rows = if let Some(v) = m.first() { v.len() } else { 0 };
-    let mut res = DMatrix::zeros(n_rows, n_cols);
-    for (col_src, mut col_dst) in m.iter().zip(res.column_iter_mut()) {
-        for (src, dst) in col_src.iter().zip(col_dst.iter_mut()) {
-            *dst = *src;
-        }
+/// Turn a list of columns into a matrix, requiring the columns to have equal
+/// lengths.
+fn to_matrix(m: Vec<Vec<i32>>, name: &str) -> PyResult<DMatrix<i32>> {
+    let n_rows = m.first().map_or(0, Vec::len);
+    if m.iter().any(|col| col.len() != n_rows) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "the vectors of \"{name}\" must all have the same length"
+        )));
     }
-    res
-}
-
-fn to_vector(v: Vec<i32>) -> DVector<i32> {
-    let len = v.len();
-    let mut res = DVector::zeros(len);
-    for (src, dst) in v.iter().zip(res.iter_mut()) {
-        *dst = *src;
-    }
-    res
-}
-
-fn to_rowvector(v: Vec<i32>) -> RowDVector<i32> {
-    let len = v.len();
-    let mut res = RowDVector::zeros(len);
-    for (src, dst) in v.iter().zip(res.iter_mut()) {
-        *dst = *src;
-    }
-    res
-}
-
-fn to_vec(v: DVector<i32>) -> Vec<i32> {
-    let len = v.len();
-    let mut res = vec![0; len];
-    for (src, dst) in v.iter().zip(res.iter_mut()) {
-        *dst = *src;
-    }
-    res
+    Ok(DMatrix::from_iterator(
+        n_rows,
+        m.len(),
+        m.into_iter().flatten(),
+    ))
 }
 
 /// Compute GV or GW invariants
@@ -64,12 +41,17 @@ pub fn compute_gvgw(
     prec: Option<u32>,
 ) -> PyResult<Vec<((Vec<i32>, usize), String)>> {
     ctrlc::set_handler(|| std::process::exit(1)).unwrap();
-    let generators = to_matrix(generators);
-    let grading_vector = to_rowvector(grading_vector);
-    let q = to_matrix(q);
-    let target_points = target_points.map(to_matrix);
-    let nefpart = nefpart.unwrap_or_default();
-    let nefpart: Vec<_> = nefpart.into_iter().map(to_vector).collect();
+    let generators = to_matrix(generators, "generators")?;
+    let grading_vector = RowDVector::from_vec(grading_vector);
+    let q = to_matrix(q, "q")?;
+    let target_points = target_points
+        .map(|m| to_matrix(m, "target_points"))
+        .transpose()?;
+    let nefpart: Vec<_> = nefpart
+        .unwrap_or_default()
+        .into_iter()
+        .map(DVector::from_vec)
+        .collect();
 
     let res = compute_gvgw_strings(
         generators,
@@ -89,7 +71,7 @@ pub fn compute_gvgw(
 
     Ok(res
         .into_iter()
-        .map(|((v, c), gvgw)| ((to_vec(v), c), gvgw))
+        .map(|((v, c), gvgw)| ((v.as_slice().to_vec(), c), gvgw))
         .collect())
 }
 

--- a/src/semigroup.rs
+++ b/src/semigroup.rs
@@ -1,9 +1,9 @@
 //! Affine semigroups that generate SCRP cones.
 //!
 //! This module contains functions to construct (truncated) affine semigroups
-//! that generate scrongly-convex rational polyhedral cones. In other words, the
+//! that generate strongly-convex rational polyhedral cones. In other words, the
 //! semigroups are of the form $S_\sigma=\sigma\cap\mathbb{Z}^n$ for a
-//! strongly-convex rational polyhedal cone $\sigma$ and some
+//! strongly-convex rational polyhedral cone $\sigma$ and some
 //! $n\in\mathbb{Z}_{>0}$.
 
 pub mod error;


### PR DESCRIPTION
## Summary

No behavior changes except one improvement noted below; CLI output on both example inputs is bit-identical to `main`.

- **`compute_gvgw_strings` dispatch**: the same thirteen-argument `run_hkty` call was spelled out eight times (2 coefficient types × 2 flags × 2 flags). A small two-level `macro_rules!` now writes the flag match once and the argument list once, cutting ~120 lines and reducing the "adding an option means touching all dispatch sites" burden.
- **`compute_omega` cleanup**: the `c1`/`c2` `nonzero` rebuild and `clean_up` ran twice back to back (and the `nonzero` rebuild a third time). One pass suffices, since `clean_up` keeps `nonzero` consistent.
- **Python binding conversions**: the hand-rolled element-by-element loops are replaced with `DMatrix::from_iterator`, `DVector::from_vec`, and `as_slice().to_vec()`. One deliberate behavior improvement: ragged inner lists (e.g. `q` columns of different lengths), which were previously **silently zero-padded/truncated**, now raise a `ValueError` naming the offending field. The public Python API always passes rectangular numpy-derived lists, so this only affects direct misuse of `_compute_gvgw`.
- **Typos** in doc comments: "scrongly" → "strongly", "polyhedal" → "polyhedral", "Efficienty" → "Efficiently", "Othersize" → "Otherwise", "polynomaials" → "polynomials".

## Test plan

- `cargo test --locked`, `cargo clippy --all-targets --locked`, and `prek -a` pass.
- `uv run pytest` passes (exercises the rewritten conversions through the extension module).
- Verified the release CLI produces byte-identical output to a `main`-built binary on `examples/threefold.yaml` and `examples/fourfold.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)