### PR TITLE
build: feature-gate the Python bindings and add crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.2.3"
 description = "Compute GV and GW invariants of CY manifolds."
 authors = ["Andres Rios Tascon"]
 edition = "2021"
+# Keep in sync with the newest API used (currently u32::is_multiple_of).
+rust-version = "1.87"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/ariostas/cygv"
+readme = "README.md"
+keywords = ["calabi-yau", "gopakumar-vafa", "gromov-witten", "mirror-symmetry"]
+categories = ["science", "mathematics", "algorithms"]
 
 [lib]
 name = "cygv"
@@ -22,10 +27,14 @@ default = ["cli"]
 # users that do not need it can depend on this crate with `default-features = false`
 # to avoid pulling in the argument and YAML parsers.
 cli = ["dep:clap", "dep:yaml-rust2"]
+# The Python bindings, i.e. the `python` module. Only the extension module built
+# by maturin needs them (see `[tool.maturin]` in pyproject.toml), so plain Rust
+# builds do not have to compile pyo3.
+python = ["dep:pyo3", "dep:ctrlc"]
 
 [dependencies]
 clap = { version = "4.5.16", features = ["derive"], optional = true }
-ctrlc = "3.4.4"
+ctrlc = { version = "3.4.4", optional = true }
 itertools = "0.14.0"
 nalgebra = "0.35.0"
 rug = "1.25.0"
@@ -34,6 +43,7 @@ yaml-rust2 = { version = "0.11", optional = true }
 [dependencies.pyo3]
 version = "0.28.2"
 features = ["abi3-py310"]
+optional = true
 
 [dev-dependencies]
 criterion = { version = "0.8.1", features = ["html_reports"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,10 @@ Repository = "https://github.com/ariostas/cygv"
 [tool.maturin]
 python-source = "python"
 # The extension module does not need the command line interface, and building it
-# would pull in the argument and YAML parsers.
+# would pull in the argument and YAML parsers. The bindings themselves live
+# behind the off-by-default `python` feature, so it has to be enabled here.
 no-default-features = true
-features = ["pyo3/extension-module"]
+features = ["python", "pyo3/extension-module"]
 
 [tool.uv]
 # Without these, uv will not rebuild the extension module when only the Rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod io;
 pub mod misc;
 pub mod polynomial;
 pub mod pool;
+#[cfg(feature = "python")]
 pub mod python;
 pub mod semigroup;
 pub mod series_inversion;
@@ -28,6 +29,7 @@ pub use semigroup::Semigroup;
 pub use polynomial::coefficient::PolynomialCoeff;
 
 // Re-export python module
+#[cfg(feature = "python")]
 #[doc(inline)]
 pub use python::cygv;
 


### PR DESCRIPTION
## Summary

- **New off-by-default `python` feature gating `src/python.rs`** (and its `ctrlc` dependency), mirroring the existing `cli` gate. Until now `pyo3` and `ctrlc` were unconditional, so every plain Rust build — the CLI, crates.io consumers, benches, and both CI workflows — compiled pyo3 for no benefit. maturin enables the feature through `[tool.maturin] features` in `pyproject.toml`, so wheel builds are unaffected; `cargo build`/`cargo test` no longer touch pyo3 at all.
- **`rust-version = "1.87"`**: the code already requires it (`u32::is_multiple_of` in `src/polynomial.rs`), but without the field older toolchains fail with an inscrutable compile error instead of a clear cargo message.
- **crates.io metadata**: explicit `readme`, plus `keywords` and `categories` for discoverability.

`Cargo.lock` is unchanged (making dependencies optional does not alter the resolution), so the lockfile-enforcing CI setup is unaffected.

## Test plan

- `cargo clippy --all-targets --locked` (default features), `cargo build --no-default-features --locked`, and `cargo clippy --locked --features python` all pass.
- `cargo test --locked` passes.
- `uv sync --extra tests --reinstall-package cygv` rebuilds the extension through maturin with the new feature configuration, and `uv run pytest` passes.

A possible follow-up (deliberately left out to keep this PR mechanical): bumping `edition` to 2024, which also moves rustfmt to the 2024 style edition and would reformat unrelated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)